### PR TITLE
Add user documentation and README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,46 +83,42 @@ Updates are delivered inside the app. When the VPN is already connected, update 
 
 If something fails, open **Logs** first. The log screen is built for debugging startup, bridge and routing problems without digging through app folders.
 
+## Documentation
+
+User docs:
+
+- [Modes](./docs/modes.md) — Proxy, System proxy, VPN · TUN, WARP-only, DPI tools and kill switch.
+- [Troubleshooting](./docs/troubleshooting.md) — practical checks, logs to collect and what not to post publicly.
+- [Privacy](./docs/privacy.md) — local data, sensitive fields, logs, WARP state and limitations.
+- [Routing](./docs/routing.md) — LAN bypass, regional rules, custom rules, DNS and connection monitor notes.
+
+Project docs:
+
+- [Architecture](./docs/architecture.md) — frontend, Rust backend, sidecars, updater and CI engine injection.
+- [Security](./SECURITY.md) — vulnerability reporting and sensitive issue handling.
+- [Contributing](./CONTRIBUTING.md) — issue and PR expectations.
+
+Developer release docs:
+
+- [Releasing](./RELEASING.md) — release ritual, annotated tags, draft releases and OTA rules.
+
 ## Security and privacy notes
 
-Ninety is open source, but it still manages powerful networking components. Please read this before using it on a sensitive system.
+Ninety is open source, but it still manages powerful networking components.
 
-- Imported profile and subscription data may contain credentials. Treat exports and logs carefully.
-- Runtime engine configs are created on demand and cleaned up after disconnect; stale runtime configs are purged on startup.
-- WARP keys and state backups are encrypted with Windows DPAPI where supported by the app backend.
-- The default engine log level is `warn` to avoid writing visited domains to disk during normal use.
-- External IP/geo lookups can be disabled in settings.
-- Subscription refreshes keep a privacy-safe default: direct fallback is opt-in.
-- The core control API listens on loopback.
+- Imported profiles and subscriptions may contain credentials.
+- Logs and screenshots must be sanitized before public reports.
+- WARP keys and state backups use Windows DPAPI where supported by the backend.
 - TUN mode, DPI tools and kill switch touch system networking. Review the settings before enabling them.
+- Ninety is a networking client, not an anonymity guarantee.
 
-For vulnerability reports, see [SECURITY.md](./SECURITY.md).
+Read [Privacy](./docs/privacy.md) for local data handling and [SECURITY.md](./SECURITY.md) for vulnerability reports.
 
 ## Architecture
 
-```text
-Tauri WebView UI
-        │
-        │ invoke / events
-        ▼
-Rust backend
-        │
-        ├─ sing-box process
-        ├─ xray bridge for XHTTP
-        ├─ NaiveProxy sidecar
-        ├─ TrustTunnel sidecar
-        ├─ WARP / WireGuard state
-        ├─ Windows system proxy
-        ├─ TUN / elevation / autostart
-        ├─ WFP kill switch
-        └─ updater, logs, backup and cleanup
-```
+At a high level, Ninety is a Tauri WebView UI talking to a Rust backend through Tauri commands and events. The backend controls sing-box, helper sidecars, WARP/WireGuard state, Windows proxy/TUN state, kill switch, updater, logs and cleanup.
 
-- **Frontend:** vanilla HTML/CSS/JavaScript, no framework and no bundler.
-- **Desktop shell:** Tauri 2 + WebView2.
-- **Backend:** Rust commands for process control, Windows integration, encrypted local secrets, logs and cleanup.
-- **Config builder:** JavaScript modules assemble sing-box/xray/sidecar configs for the active source, mode and options.
-- **CI:** GitHub Actions builds the Windows release and injects the external engines that are not stored in this repository.
+See [Architecture](./docs/architecture.md) for the full overview.
 
 ## Build from source
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -83,46 +83,42 @@ NaiveProxy и TrustTunnel обслуживаются собственными к
 
 Если что-то не работает, сначала откройте **Логи**. Экран логов сделан для диагностики старта, мостов и маршрутизации без ручного поиска файлов в папках приложения.
 
+## Документация
+
+Пользовательские разделы:
+
+- [Modes](./docs/modes.md) — Proxy, System proxy, VPN · TUN, WARP-only, DPI tools и kill switch.
+- [Troubleshooting](./docs/troubleshooting.md) — практичные проверки, какие логи собрать и что нельзя публиковать.
+- [Privacy](./docs/privacy.md) — локальные данные, чувствительные поля, логи, WARP-состояние и ограничения.
+- [Routing](./docs/routing.md) — LAN bypass, региональные правила, пользовательские правила, DNS и монитор соединений.
+
+Проектные разделы:
+
+- [Architecture](./docs/architecture.md) — frontend, Rust backend, sidecar'ы, updater и CI-подготовка движков.
+- [Security](./SECURITY.md) — сообщения об уязвимостях и чувствительных проблемах.
+- [Contributing](./CONTRIBUTING.md) — ожидания к issues и PR.
+
+Для разработки релизов:
+
+- [Releasing](./RELEASING.md) — релизный ритуал, annotated tags, draft releases и OTA-правила.
+
 ## Безопасность и приватность
 
-Ninety открыт по исходникам, но он управляет сильными сетевыми компонентами. Перед использованием на чувствительной системе стоит понимать следующее:
+Ninety открыт по исходникам, но он управляет сильными сетевыми компонентами.
 
-- Импортированные профили и подписки могут содержать креды. Не публикуйте экспорты и логи без очистки.
-- Runtime-конфиги движков создаются по требованию и чистятся после отключения; устаревшие runtime-конфиги удаляются при старте.
-- WARP-ключи и backup состояния шифруются через Windows DPAPI там, где это поддержано бэкендом приложения.
-- Уровень логов по умолчанию — `warn`, чтобы в обычном режиме не писать посещённые домены на диск.
-- Внешние IP/geo-запросы можно отключить в настройках.
-- Обновление подписок по умолчанию приватное: прямой fallback включается только явно.
-- Управляющий API ядра слушает только loopback.
+- Импортированные профили и подписки могут содержать креды.
+- Логи и скриншоты нужно очищать перед публичными reports.
+- WARP-ключи и backup состояния используют Windows DPAPI там, где это поддержано бэкендом.
 - TUN-режим, DPI-инструменты и kill switch меняют сетевое состояние системы. Перед включением проверьте настройки.
+- Ninety — сетевой клиент, а не гарантия анонимности.
 
-Для сообщений об уязвимостях см. [SECURITY.md](./SECURITY.md).
+Подробнее см. [Privacy](./docs/privacy.md), для уязвимостей — [SECURITY.md](./SECURITY.md).
 
 ## Архитектура
 
-```text
-Tauri WebView UI
-        │
-        │ invoke / events
-        ▼
-Rust backend
-        │
-        ├─ sing-box process
-        ├─ xray bridge for XHTTP
-        ├─ NaiveProxy sidecar
-        ├─ TrustTunnel sidecar
-        ├─ WARP / WireGuard state
-        ├─ Windows system proxy
-        ├─ TUN / elevation / autostart
-        ├─ WFP kill switch
-        └─ updater, logs, backup and cleanup
-```
+В общих чертах Ninety — это Tauri WebView UI, который общается с Rust backend через Tauri commands/events. Бэкенд управляет sing-box, sidecar'ами, WARP/WireGuard state, системным прокси Windows, TUN, kill switch, updater, логами и cleanup.
 
-- **Фронтенд:** vanilla HTML/CSS/JavaScript без фреймворка и сборщика.
-- **Desktop-оболочка:** Tauri 2 + WebView2.
-- **Бэкенд:** Rust-команды для управления процессами, интеграции с Windows, шифрования локальных секретов, логов и cleanup.
-- **Config builder:** JS-модули собирают конфиги sing-box/xray/sidecar под активный источник, режим и настройки.
-- **CI:** GitHub Actions собирает Windows-релиз и подтягивает внешние движки, которые не хранятся в репозитории.
+Полный обзор: [Architecture](./docs/architecture.md).
 
 ## Сборка из исходников
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,76 @@
+# Architecture
+
+Ninety is a Tauri 2 desktop app with a vanilla JavaScript frontend and a Rust backend. The app builds runtime configs for sing-box and helper sidecars based on the selected source, mode and settings.
+
+```text
+Tauri WebView UI
+        │
+        │ invoke / events
+        ▼
+Rust backend
+        │
+        ├─ sing-box process
+        ├─ xray bridge for XHTTP
+        ├─ NaiveProxy sidecar
+        ├─ TrustTunnel sidecar
+        ├─ WARP / WireGuard state
+        ├─ Windows system proxy
+        ├─ TUN / elevation / autostart
+        ├─ WFP kill switch
+        └─ updater, logs, backup and cleanup
+```
+
+## Frontend
+
+The frontend lives under `src/`. It uses vanilla HTML, CSS and JavaScript without a framework or bundler.
+
+The UI owns screens, local presentation state, i18n, settings forms, import flows and client-side config-building helpers.
+
+## Rust backend
+
+The backend lives under `src-tauri/src/`. It exposes Tauri commands and events for Windows integration and runtime control.
+
+The backend is responsible for:
+
+- starting and stopping local engine processes;
+- Windows system proxy changes;
+- TUN elevation and autostart behavior;
+- WARP/WireGuard state;
+- WFP kill switch controls;
+- logs, backup, cleanup and update support.
+
+## Config builder
+
+JavaScript modules assemble runtime configs for the active source, mode and options.
+
+The builder decides which inbounds, outbounds, DNS settings, routing rules and sidecar bridges are needed. The runtime config is generated for the current connection and should not be treated as a stable user-authored file.
+
+## Sidecars
+
+sing-box remains the central router. Some protocols or transports need helper sidecars:
+
+- xray-core for XHTTP bridge behavior;
+- NaiveProxy client for NaiveProxy nodes;
+- TrustTunnel client for TrustTunnel endpoints.
+
+Sidecars listen locally and are wired into sing-box through local bridge routes. The user still sees one source and one connection state.
+
+## Updater
+
+Ninety uses Tauri updater metadata from `latest.json` assets published with releases.
+
+The OTA notes shown by the app come from the `notes` field in `latest.json`, which is generated during the tag build. The human-facing GitHub Release body can be polished for GitHub readers, but editing it after release does not rewrite an already published `latest.json`.
+
+## CI and external engines
+
+The repository does not store the full release engine binaries directly. GitHub Actions prepares them during the Windows release workflow.
+
+This keeps the repository smaller and makes release inputs explicit in CI:
+
+- build or download pinned engine versions;
+- verify hashes where applicable;
+- place binaries where Tauri expects sidecars;
+- build and sign Windows artifacts;
+- generate and publish `latest.json`.
+
+For the release ritual, see [RELEASING.md](../RELEASING.md).

--- a/docs/modes.md
+++ b/docs/modes.md
@@ -1,0 +1,138 @@
+# Connection modes and safety notes
+
+Ninety is a Windows networking client. The selected mode changes how traffic enters the local engines and how much Windows networking state the app has to touch.
+
+Ninety does not make a provider, server or configuration safe by itself. Treat imported profiles, subscriptions and logs as sensitive data.
+
+## Proxy
+
+Proxy mode starts local proxy listeners on `127.0.0.1`. Apps that support SOCKS or HTTP proxy settings can be pointed at Ninety manually.
+
+Use it when:
+
+- you want the smallest system impact;
+- you only need selected apps to use Ninety;
+- you are testing a profile or subscription without changing Windows proxy settings.
+
+Admin rights: not normally required.
+
+What can break:
+
+- apps that are not configured to use the local proxy will keep using the network directly;
+- browser or app proxy settings can point to the wrong local port;
+- DNS behavior depends on the app and the selected profile.
+
+Diagnostics: open the **Logs** screen and check startup, import, bridge and connection messages.
+
+## System proxy
+
+System proxy mode configures the Windows user-level system proxy to point at Ninety's local proxy. This is the recommended default for many desktop users.
+
+Use it when:
+
+- you want browsers and many desktop apps to follow the Windows proxy setting;
+- you do not want full TUN routing;
+- you want a default that usually does not require elevation.
+
+Admin rights: not normally required.
+
+What can break:
+
+- some apps ignore the Windows system proxy;
+- a crash or external tool can leave Windows proxy state different from what you expect;
+- corporate, school or managed Windows policy can override proxy settings.
+
+Diagnostics: open **Logs**, then verify Windows proxy settings if traffic does not recover after disconnect.
+
+## VPN · TUN
+
+VPN · TUN mode routes system traffic through a TUN interface. This mode changes more Windows networking state than Proxy or System proxy mode.
+
+Use it when:
+
+- you need apps that do not support proxy settings to use the tunnel;
+- you need routing rules to apply closer to system traffic;
+- you understand that elevation and driver/runtime components may be involved.
+
+Admin rights: required. Ninety may ask for UAC elevation when entering or restoring TUN mode.
+
+What can break:
+
+- UAC cancellation prevents TUN from starting;
+- driver, firewall, antivirus or endpoint security software can block TUN setup;
+- routing, DNS or kill switch settings can make traffic look offline;
+- another VPN client can conflict with the TUN interface or routes.
+
+Diagnostics: open **Logs** first. If TUN was cancelled at UAC, switch back to Proxy or System proxy and retry only after checking the selected settings.
+
+## WARP-only
+
+WARP-only mode can run without a normal profile or subscription when WARP is registered and enabled in settings. Ninety builds the runtime route around the WARP/WireGuard state.
+
+Use it when:
+
+- you want to test WARP without importing a subscription;
+- you need a clean baseline before adding profiles or routing rules;
+- you are debugging WARP registration or endpoint scanning.
+
+Admin rights: depends on the selected connection mode. WARP-only with VPN · TUN still requires elevation.
+
+What can break:
+
+- WARP must be registered before it can be used;
+- endpoint scans can fail on restricted or unstable networks;
+- changing WARP settings while connected may require a reconnect.
+
+Diagnostics: check **Settings -> WARP** and the **Logs** screen. Do not post WARP account, device or key material publicly.
+
+## DPI tools
+
+DPI tools are separate compatibility tools for specific network conditions. They can update strategy/list data, manage runtime helper state and clean up driver state.
+
+Use them only when:
+
+- normal Proxy, System proxy or VPN · TUN mode does not behave correctly on the current network;
+- you can test carefully and revert the setting if it makes the connection worse.
+
+Admin rights: may be required depending on the selected action and driver state.
+
+What can break:
+
+- helper tools can fail to start or stop cleanly;
+- driver cleanup can affect active networking until you reconnect;
+- combining DPI tools with TUN mode can be confusing if you change several settings at once.
+
+Diagnostics: open the DPI screen and **Logs**. Public bug reports should describe the symptom and selected app mode, not detailed operational bypass recipes.
+
+## Kill switch
+
+Kill switch is designed to block traffic when Ninety cannot keep the intended protected state. It uses Windows networking controls and should be treated as a safety feature with real system impact.
+
+Use it when:
+
+- you understand how to recover if traffic is blocked;
+- you have tested your selected mode and routing rules first;
+- you need stricter behavior on disconnect or failure.
+
+Admin rights: may be required because the feature touches Windows filtering state.
+
+What can break:
+
+- traffic can remain blocked if the app is interrupted during a state change;
+- another firewall or security product can conflict with the rules;
+- Proxy mode expectations can differ from TUN mode expectations.
+
+Diagnostics: open **Logs**, disable kill switch from settings if possible, and reconnect. If traffic is still blocked, include sanitized logs in a bug report.
+
+## What to include in reports
+
+When opening an issue, include:
+
+- Ninety version;
+- Windows version;
+- install type: NSIS `.exe`, MSI or development build;
+- connection mode;
+- source type: subscription, standalone profile or WARP-only;
+- sanitized logs or screenshots.
+
+Do not post subscription URLs, UUIDs, passwords, tokens, private keys, WARP account/device data or full configs publicly.

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,0 +1,89 @@
+# Privacy and local data
+
+Ninety is a local Windows networking client. It does not run a hosted VPN service, and it does not make a server or provider trustworthy by itself.
+
+## What may be stored locally
+
+Depending on what you use, Ninety can store:
+
+- imported profiles and subscriptions;
+- active source and selected node state;
+- user settings;
+- WARP registration and endpoint state;
+- traffic and quality history used by the UI;
+- update state;
+- runtime backup state for session restore;
+- logs written by the app and helper engines.
+
+Some of this data may identify your provider, server, account or local Windows user. Treat the app data directory, exports and logs as sensitive.
+
+## Sensitive profile and subscription data
+
+Profiles and subscriptions can contain credentials, including:
+
+- subscription URLs;
+- UUIDs and passwords;
+- access tokens;
+- private keys;
+- server addresses;
+- transport-specific secrets.
+
+Do not paste real profiles, full configs or raw subscription responses into public issues. Use placeholders and sanitized logs.
+
+## WARP keys and backup state
+
+WARP/WireGuard state can contain key material and device/account data. Where supported by the backend, Ninety encrypts WARP keys and state backups with Windows DPAPI.
+
+DPAPI protects data for the local Windows environment. It does not make copied logs, screenshots or manually exported files safe to publish.
+
+## Logs
+
+The default engine log level is `warn`. This reduces the chance of writing visited domains or detailed connection metadata to disk during normal use.
+
+Logs can still contain sensitive context. Before sharing them, remove credentials, private endpoints, account names and local paths.
+
+## External lookups
+
+Ninety can use external IP/geo lookups for connection diagnostics and UI status. These lookups can be disabled in settings.
+
+Disabling external lookups can make location or status information less complete, but it reduces extra network requests made by the app.
+
+## Subscription refresh fallback
+
+Subscription refresh is designed with a privacy-safe default: direct fallback is opt-in. If refresh through the active connection fails, Ninety should not silently retry directly unless the user enables that behavior.
+
+This matters because subscription URLs are often credentials.
+
+## Runtime configs
+
+Runtime configs are generated on demand for the active source, mode and options. They can contain credentials needed by local engines.
+
+Ninety cleans runtime configs after disconnect and purges stale runtime configs on startup. This cleanup reduces exposure, but it does not replace careful handling of local backups, logs or filesystem access.
+
+## What Ninety does not promise
+
+Ninety does not promise anonymity.
+
+Ninety does not control:
+
+- your server or subscription provider;
+- upstream network behavior;
+- Windows policy, firewall or endpoint security software;
+- apps that bypass system proxy settings;
+- mistakes in imported configs or routing rules.
+
+An unsafe provider stays unsafe. A bad configuration can still leak traffic or break connectivity. Review your settings before enabling VPN · TUN, DPI tools or kill switch.
+
+## Public issue safety
+
+Public reports are useful, but they must be sanitized. Do not post:
+
+- private subscription URLs;
+- UUIDs, passwords or access tokens;
+- private keys;
+- WARP account/device data;
+- full configs;
+- real private server addresses;
+- personally identifying paths or account names.
+
+For security-sensitive findings, follow [SECURITY.md](../SECURITY.md).

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -1,0 +1,108 @@
+# Routing
+
+Ninety builds routing rules for sing-box from the selected mode, source and settings. Routing decides whether traffic should go through the selected VPN path, go direct or be blocked.
+
+This document explains the logic at a user and diagnostics level. It is not an operational guide for bypassing network controls.
+
+## Core actions
+
+Routing rules generally resolve to one of three actions:
+
+- **Through VPN**: send matching traffic through the selected proxy, tunnel or WARP path.
+- **Direct**: send matching traffic outside the selected VPN path.
+- **Block**: reject matching traffic.
+
+The visible labels in the app may be localized, but the behavior maps to these three outcomes.
+
+## LAN bypass
+
+LAN bypass keeps local network destinations reachable directly. This is useful for routers, printers, NAS devices, local development servers and other private network resources.
+
+If a local device is not reachable while connected, check whether LAN bypass is enabled and whether the destination is really in a private/local range.
+
+## Regional and built-in rules
+
+Ninety can apply built-in regional and safety-oriented rule sets, such as LAN, regional defaults and selected ad/malware/phishing lists.
+
+These rules are meant to provide practical defaults. If behavior is surprising, disable optional rule sets one at a time and retest.
+
+## Custom rules
+
+Custom rules can match:
+
+- domains;
+- IP addresses or subnets;
+- process names.
+
+Each custom rule has an action: through VPN, direct or block. Custom rules are intended to be evaluated before broad defaults so user intent can override regional defaults.
+
+Safe debugging pattern:
+
+1. Disable custom rules.
+2. Confirm the baseline works.
+3. Re-enable one rule.
+4. Test again.
+5. Repeat until the unexpected rule is found.
+
+Do not include private domains, private IP ranges or internal process names in public screenshots unless they are sanitized.
+
+## DNS relation
+
+DNS behavior depends on the selected mode and generated config. A domain rule can only work as expected if the destination is visible to the routing layer in a form the rule can match.
+
+If DNS behavior looks wrong:
+
+- compare Proxy/System proxy and VPN · TUN mode;
+- check whether the app uses its own DNS behavior;
+- test without custom DNS-related settings;
+- collect sanitized Logs output.
+
+## Proxy and System proxy modes
+
+In Proxy mode, only apps configured to use Ninety's local proxy enter the routing pipeline.
+
+In System proxy mode, apps that respect the Windows system proxy enter the routing pipeline. Apps that ignore Windows proxy settings may still connect directly.
+
+If a rule appears ignored in these modes, first confirm that the app traffic is actually using Ninety.
+
+## VPN · TUN mode
+
+In VPN · TUN mode, traffic enters through a TUN interface and routing applies closer to system traffic. This can cover apps that do not support proxy settings, but it also touches more Windows networking state.
+
+TUN mode can be affected by:
+
+- UAC elevation;
+- other VPN clients;
+- firewall or endpoint security tools;
+- DNS settings;
+- kill switch rules;
+- process-name matching differences.
+
+When debugging TUN routing, start with a minimal config and add custom rules gradually.
+
+## WARP routing
+
+When WARP is enabled, some generated routes can use the WARP/WireGuard path. WARP-only mode can work without a normal profile or subscription after WARP registration.
+
+Do not post WARP keys, account/device data or raw state files publicly.
+
+## Connection monitor
+
+The connections view is useful for confirming what is active while connected. Use it to compare expected rules with actual traffic.
+
+If the monitor shows unexpected traffic:
+
+- check the process name;
+- check destination domain or IP;
+- check which mode is active;
+- temporarily disable broad custom rules;
+- attach sanitized screenshots or logs to the issue.
+
+## Safe troubleshooting checklist
+
+- Start from System proxy mode unless the issue is TUN-specific.
+- Disable custom rules and optional lists.
+- Test one profile or subscription source.
+- Re-enable rules one at a time.
+- Check **Logs** after each failed start or reconnect.
+- Sanitize all logs and screenshots before posting publicly.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,138 @@
+# Troubleshooting
+
+Start with the **Logs** screen. It is the main place to diagnose imports, engine startup, bridges, routing, WARP, updater state and cleanup.
+
+Do not post private subscription URLs, UUIDs, passwords, tokens, private keys, WARP account/device data or full configs in public issues.
+
+## Before opening an issue
+
+1. Update to the latest release from GitHub Releases.
+2. Reproduce with the smallest setup you can: one source, one mode, one changed setting.
+3. Check the **Logs** screen.
+4. Sanitize logs and screenshots.
+5. Include Ninety version, Windows version, install type, mode and source type.
+
+Useful report template:
+
+```text
+Ninety version:
+Windows version:
+Install type: NSIS .exe / MSI / dev build
+Connection mode: Proxy / System proxy / VPN · TUN / WARP-only
+Source type: subscription / standalone profile / WARP-only
+Protocol/transport, if relevant:
+Steps to reproduce:
+Expected result:
+Actual result:
+Sanitized logs or screenshots:
+```
+
+## App does not start
+
+- Try launching from the Start menu again after a few seconds.
+- Check whether antivirus or endpoint security blocked the executable.
+- If this happened after an update, install the latest `.exe` or `.msi` from Releases.
+- Include Windows version and install type in the issue.
+
+## Installer or update problems
+
+- Prefer the latest `.exe` installer for normal desktop installation.
+- Use MSI only when your environment needs MSI deployment.
+- Disconnect before manually installing over an active TUN/WARP session.
+- If the in-app updater fails, check whether your current network blocks GitHub or the configured update endpoint.
+- Do not edit release `latest.json` locally or ask users to replace it manually.
+
+## Import does not work
+
+- Check whether the source is a subscription URL, standalone profile link or TrustTunnel `.toml` endpoint file.
+- Try importing one link first before pasting a multi-link list.
+- Remove unrelated text around the link.
+- Do not share the real subscription URL publicly. Replace hostnames, IDs and credentials with placeholders.
+
+## Subscription refresh fails
+
+- Confirm the subscription URL still works outside Ninety without exposing it publicly.
+- Check whether refresh is enabled for that subscription.
+- If connected, try refreshing once while connected and once after disconnecting.
+- Direct fallback is opt-in. If it is disabled, Ninety should not silently retry subscription refresh directly.
+- Attach sanitized Logs output.
+
+## Connected but no internet
+
+- Identify the mode: Proxy, System proxy, VPN · TUN or WARP-only.
+- In Proxy mode, verify the app/browser is configured to use Ninety's local proxy.
+- In System proxy mode, check whether the affected app respects Windows proxy settings.
+- In VPN · TUN mode, check DNS, routing rules, kill switch and other VPN clients.
+- Try a different node or WARP endpoint if available.
+- Check **Logs** for engine startup, bridge and DNS messages.
+
+## System proxy was not restored
+
+- Disconnect from Ninety if it is still connected.
+- Check Windows proxy settings manually.
+- Look for restore or cleanup messages in **Logs**.
+- Mention whether another proxy/VPN tool was running at the same time.
+
+## TUN mode fails or UAC was cancelled
+
+- TUN requires elevation. If UAC is cancelled, the mode cannot start.
+- Switch back to Proxy or System proxy before retrying.
+- Check whether another VPN client, firewall or endpoint security product is active.
+- Include the exact point where elevation failed and sanitized Logs output.
+
+## WARP registration or scan issues
+
+- Check **Settings -> WARP** first.
+- Confirm WARP is registered before testing WARP-only mode.
+- Endpoint scans can fail on restricted, unstable or captive networks.
+- Do not post WARP keys, account IDs, device data or backup state publicly.
+
+## DNS issues
+
+- Try a minimal setup without custom routing rules.
+- Check whether DNS differs between Proxy/System proxy and VPN · TUN mode.
+- If only one app fails, it may be bypassing the Windows proxy or using its own DNS behavior.
+- Include the selected mode and sanitized Logs output.
+
+## Routing rules behave unexpectedly
+
+- Disable custom rules and retest with defaults.
+- Re-enable one rule at a time.
+- Check rule type: domain, IP/subnet or process.
+- Check action: through VPN, direct or block.
+- TUN mode can apply routing differently from Proxy/System proxy because traffic enters the engine differently.
+- Use the connections monitor to confirm which process or destination is actually active.
+
+## DPI tools fail to start or stop
+
+- Revert recent DPI tool changes and reconnect.
+- Avoid changing DPI tools, TUN mode and kill switch at the same time while debugging.
+- Driver cleanup may require reconnecting or restarting the app.
+- Public reports should describe the symptom and state, not detailed bypass instructions.
+
+## Kill switch blocks traffic
+
+- Disable kill switch if the UI is reachable.
+- Disconnect and reconnect using System proxy or Proxy mode first.
+- Check whether another firewall or endpoint security product is managing similar rules.
+- Include sanitized Logs output and the active mode.
+
+## Logs to collect
+
+Useful logs are:
+
+- import or subscription errors;
+- engine startup and shutdown messages;
+- bridge startup errors for xray, NaiveProxy or TrustTunnel;
+- WARP registration or scan messages;
+- routing and DNS warnings;
+- update errors.
+
+Before sharing logs publicly, remove:
+
+- subscription URLs;
+- UUIDs, passwords and access tokens;
+- private keys;
+- WARP account/device data;
+- real private server addresses;
+- personally identifying paths or account names.


### PR DESCRIPTION
## Summary

- Add user-facing documentation for connection modes, troubleshooting, privacy, architecture and routing.
- Keep the README as a landing page by linking to the new docs and shortening long privacy/architecture sections.
- Document release/OTA expectations at a high level without editing release assets or latest.json.

## GitHub checks performed outside this PR

- Verified issue #6 stays open and pinned with feedback/roadmap/pinned/help wanted labels and pathetixx assigned.
- Verified Release v0.2.3 exists, has a non-empty human-facing body, is not draft or prerelease, is the current GitHub latest release, and still has latest.json plus installer assets.
- Did not edit latest.json, tags, release assets or release process state.

## Validation

- npm run lint
- npm test
- Markdown relative link check
- git diff --check