### PR TITLE
fix: preserve backup when localStorage is empty

### DIFF
--- a/src/lib/state-backup.js
+++ b/src/lib/state-backup.js
@@ -18,14 +18,22 @@ const invoke = window.__TAURI__?.core?.invoke
 
 function snapshot({ includeUpdateResume = false } = {}) {
   const out = { __schemaVersion: BACKUP_SCHEMA_VERSION, __createdAt: Date.now() };
+  let storedKeys = 0;
   for (let i = 0; i < localStorage.length; i++) {
     const k = localStorage.key(i);
     // Маркер возврата сессии нужен только в снимке, который делаем прямо перед
     // OTA. В обычном бэкапе он не должен переживать произвольный перезапуск.
     if (!shouldBackupStorageKey(k) && !(includeUpdateResume && k === STORAGE_KEYS.updateResume)) continue;
     const v = localStorage.getItem(k);
-    if (v != null) out[k] = v;
+    if (v != null) {
+      out[k] = v;
+      storedKeys++;
+    }
   }
+  // Дефолтные CORE-ключи нужны только чтобы частичный, но реальный storage дал
+  // валидный snapshot. Полностью пустое хранилище не должно перетирать полезный
+  // дисковый backup искусственными {}, [], [].
+  if (storedKeys === 0) return null;
   if (out["ninety.options.v1"] == null) out["ninety.options.v1"] = "{}";
   if (out["ninety.profiles.v1"] == null) out["ninety.profiles.v1"] = "[]";
   if (out["ninety.subscriptions.v1"] == null) out["ninety.subscriptions.v1"] = "[]";
@@ -40,7 +48,7 @@ export function backupNow({ includeUpdateResume = false } = {}) {
   backupInFlight = backupInFlight.catch(() => {}).then(async () => {
     const snap = snapshot({ includeUpdateResume });
     // Пустое хранилище не пишем — не перетираем полезный бэкап пустотой.
-    if (!Object.keys(snap).some(k => !k.startsWith("__"))) return;
+    if (!snap) return;
     try { await invoke("state_backup_save", { json: JSON.stringify(snap) }); }
     catch (e) { console.warn("state backup failed", e); }
   });

--- a/tests/state-backup.test.mjs
+++ b/tests/state-backup.test.mjs
@@ -16,6 +16,7 @@ function makeStorage() {
 const localStorage = makeStorage();
 const sessionStorage = makeStorage();
 let savedSnapshot = null;
+let saveCalls = 0;
 
 globalThis.localStorage = localStorage;
 globalThis.sessionStorage = sessionStorage;
@@ -24,6 +25,7 @@ globalThis.window = {
     core: {
       invoke: async (cmd, args) => {
         if (cmd === "state_backup_save") {
+          saveCalls++;
           savedSnapshot = args.json;
           return;
         }
@@ -35,6 +37,18 @@ globalThis.window = {
 };
 
 const { backupForUpdate, backupNow, restoreIfEmpty, validateSnapshot } = await import("/lib/state-backup.js");
+
+test("пустой localStorage не перетирает существующий дисковый снимок", async () => {
+  localStorage.clear();
+  sessionStorage.clear();
+  savedSnapshot = "preserved-backup";
+  const before = saveCalls;
+
+  await backupNow();
+
+  assert.equal(saveCalls, before);
+  assert.equal(savedSnapshot, "preserved-backup");
+});
 
 test("OTA-снимок возвращает активный профиль и resume-маркер", async () => {
   localStorage.clear();


### PR DESCRIPTION
## Что изменено

- backup snapshot теперь отличает реальные ключи localStorage от искусственно добавляемых CORE-дефолтов;
- полностью пустое хранилище больше не вызывает `state_backup_save`;
- добавлен regression-тест, подтверждающий, что существующий дисковый backup не перезаписывается.

## Причина

Раньше `snapshot()` сначала добавлял `{}`, `[]`, `[]`, а затем `backupNow()` считал такой снимок непустым. После очистки WebView2 это могло заменить полезный backup пустым состоянием.

## Проверка

- новый JS unit test для пустого localStorage;
- существующие тесты backup/restore остаются без изменения контракта.

Draft для дополнительного просмотра в Codex.