### PR TITLE
fix: preserve OTA resume snapshot during background backup

### DIFF
--- a/src/lib/state-backup.js
+++ b/src/lib/state-backup.js
@@ -46,6 +46,15 @@ export function backupNow({ includeUpdateResume = false, strict = false } = {}) 
   // Каждая заявка получает собственный Promise: OTA не начнёт установку, пока
   // именно её снимок не записан после возможного обычного бэкапа в очереди.
   backupInFlight = backupInFlight.catch(() => {}).then(async () => {
+    // Пока жив OTA-журнал, обычные debounce/periodic backup не имеют права
+    // перезаписать строгий снимок версией без ninety.update.resume. После
+    // подтверждённого RuntimeReady main.js удаляет журнал — фоновые записи
+    // автоматически возобновляются без отдельного lock/unlock API.
+    if (!includeUpdateResume) {
+      try {
+        if (localStorage.getItem(STORAGE_KEYS.updateResume) != null) return;
+      } catch {}
+    }
     const snap = snapshot({ includeUpdateResume });
     // Пустое хранилище не пишем — не перетираем полезный бэкап пустотой.
     if (!snap) return;

--- a/src/lib/state-backup.js
+++ b/src/lib/state-backup.js
@@ -41,25 +41,30 @@ function snapshot({ includeUpdateResume = false } = {}) {
 }
 
 let backupInFlight = Promise.resolve();
+// Включается только ПОСЛЕ успешной записи строгого OTA-снимка. Само наличие
+// resume-маркера ещё не означает, что такой снимок уже существует: updater
+// сначала пишет marker в localStorage, затем вызывает backupForUpdate().
+let otaSnapshotProtected = false;
 
 export function backupNow({ includeUpdateResume = false, strict = false } = {}) {
   // Каждая заявка получает собственный Promise: OTA не начнёт установку, пока
   // именно её снимок не записан после возможного обычного бэкапа в очереди.
   backupInFlight = backupInFlight.catch(() => {}).then(async () => {
-    // Пока жив OTA-журнал, обычные debounce/periodic backup не имеют права
-    // перезаписать строгий снимок версией без ninety.update.resume. После
-    // подтверждённого RuntimeReady main.js удаляет журнал — фоновые записи
-    // автоматически возобновляются без отдельного lock/unlock API.
-    if (!includeUpdateResume) {
-      try {
-        if (localStorage.getItem(STORAGE_KEYS.updateResume) != null) return;
-      } catch {}
+    if (!includeUpdateResume && otaSnapshotProtected) {
+      let resumePending = false;
+      try { resumePending = localStorage.getItem(STORAGE_KEYS.updateResume) != null; } catch {}
+      // Пока жив OTA-журнал, debounce/periodic backup не имеет права перезаписать
+      // уже подтверждённый строгий снимок версией без ninety.update.resume.
+      if (resumePending) return;
+      // RuntimeReady удалил журнал: фоновые снимки снова разрешены.
+      otaSnapshotProtected = false;
     }
     const snap = snapshot({ includeUpdateResume });
     // Пустое хранилище не пишем — не перетираем полезный бэкап пустотой.
     if (!snap) return;
     try {
       await invoke("state_backup_save", { json: JSON.stringify(snap) });
+      if (includeUpdateResume) otaSnapshotProtected = true;
     } catch (e) {
       console.warn("state backup failed", e);
       // Фоновые снимки остаются best-effort, но OTA обязан остановиться до

--- a/src/lib/state-backup.js
+++ b/src/lib/state-backup.js
@@ -41,30 +41,24 @@ function snapshot({ includeUpdateResume = false } = {}) {
 }
 
 let backupInFlight = Promise.resolve();
-// Включается только ПОСЛЕ успешной записи строгого OTA-снимка. Само наличие
-// resume-маркера ещё не означает, что такой снимок уже существует: updater
-// сначала пишет marker в localStorage, затем вызывает backupForUpdate().
-let otaSnapshotProtected = false;
 
 export function backupNow({ includeUpdateResume = false, strict = false } = {}) {
   // Каждая заявка получает собственный Promise: OTA не начнёт установку, пока
   // именно её снимок не записан после возможного обычного бэкапа в очереди.
   backupInFlight = backupInFlight.catch(() => {}).then(async () => {
-    if (!includeUpdateResume && otaSnapshotProtected) {
-      let resumePending = false;
-      try { resumePending = localStorage.getItem(STORAGE_KEYS.updateResume) != null; } catch {}
-      // Пока жив OTA-журнал, debounce/periodic backup не имеет права перезаписать
-      // уже подтверждённый строгий снимок версией без ninety.update.resume.
-      if (resumePending) return;
-      // RuntimeReady удалил журнал: фоновые снимки снова разрешены.
-      otaSnapshotProtected = false;
+    // Resume-журнал — durable lock, который переживает relaunch. Пока он жив,
+    // debounce/periodic backup не имеет права перезаписать OTA-снимок версией
+    // без ninety.update.resume. RuntimeReady удаляет журнал перед обычным backup.
+    if (!includeUpdateResume) {
+      try {
+        if (localStorage.getItem(STORAGE_KEYS.updateResume) != null) return;
+      } catch {}
     }
     const snap = snapshot({ includeUpdateResume });
     // Пустое хранилище не пишем — не перетираем полезный бэкап пустотой.
     if (!snap) return;
     try {
       await invoke("state_backup_save", { json: JSON.stringify(snap) });
-      if (includeUpdateResume) otaSnapshotProtected = true;
     } catch (e) {
       console.warn("state backup failed", e);
       // Фоновые снимки остаются best-effort, но OTA обязан остановиться до

--- a/tests/state-backup-ota-race.test.mjs
+++ b/tests/state-backup-ota-race.test.mjs
@@ -1,0 +1,50 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+function makeStorage() {
+  const data = new Map();
+  return {
+    get length() { return data.size; },
+    key: (i) => Array.from(data.keys())[i] ?? null,
+    getItem: (key) => data.has(key) ? data.get(key) : null,
+    setItem: (key, value) => data.set(key, String(value)),
+    removeItem: (key) => data.delete(key),
+    clear: () => data.clear(),
+  };
+}
+
+const localStorage = makeStorage();
+let savedSnapshot = null;
+let saveCalls = 0;
+
+globalThis.localStorage = localStorage;
+globalThis.sessionStorage = makeStorage();
+globalThis.window = {
+  __TAURI__: {
+    core: {
+      invoke: async (command, args) => {
+        if (command !== "state_backup_save") throw new Error(`unexpected invoke: ${command}`);
+        saveCalls++;
+        savedSnapshot = args.json;
+      },
+    },
+  },
+};
+
+const { backupForUpdate, backupSoon } = await import("/lib/state-backup.js");
+
+test("delayed background backup cannot overwrite the OTA resume snapshot", async () => {
+  localStorage.setItem("ninety.options.v1", "{}");
+  localStorage.setItem("ninety.profiles.v1", "[]");
+  localStorage.setItem("ninety.subscriptions.v1", "[]");
+  localStorage.setItem("ninety.update.resume", JSON.stringify({ vpn: true, dpi: false }));
+
+  backupSoon(5);
+  await backupForUpdate();
+  const afterStrictSave = saveCalls;
+
+  await new Promise((resolve) => setTimeout(resolve, 20));
+
+  assert.equal(saveCalls, afterStrictSave);
+  assert.deepEqual(JSON.parse(savedSnapshot)["ninety.update.resume"], JSON.stringify({ vpn: true, dpi: false }));
+});

--- a/tests/state-backup.test.mjs
+++ b/tests/state-backup.test.mjs
@@ -71,11 +71,11 @@ test("OTA-снимок возвращает активный профиль и r
   localStorage.setItem("ninety.profiles.v1", JSON.stringify([{ id: "p-last", name: "Последний" }]));
   localStorage.setItem("ninety.profiles.active", "p-last");
   localStorage.setItem("ninety.active.kind", "single");
-  localStorage.setItem("ninety.update.resume", JSON.stringify({ vpn: true, dpi: false }));
 
   await backupNow();
   assert.equal(JSON.parse(savedSnapshot)["ninety.update.resume"], undefined);
 
+  localStorage.setItem("ninety.update.resume", JSON.stringify({ vpn: true, dpi: false }));
   await backupForUpdate();
   const otaSnapshot = JSON.parse(savedSnapshot);
   assert.equal(otaSnapshot["ninety.profiles.active"], "p-last");


### PR DESCRIPTION
## Что исправлено

- обычный debounce/periodic backup пропускается, пока в `localStorage` существует `ninety.update.resume`;
- строгий `backupForUpdate()` по-прежнему записывает полный OTA-снимок с resume-журналом;
- после подтверждённого RuntimeReady журнал удаляется существующим кодом, и фоновые backup автоматически возобновляются;
- добавлен regression-тест для последовательности `backupSoon()` → `backupForUpdate()` → срабатывание отложенного таймера.

## Причина

Ранее уже поставленный `backupSoon()` или периодический `backupNow()` мог выполниться после строгого OTA-снимка и перезаписать его версией без `ninety.update.resume`. При потере WebView2 во время обновления профили восстанавливались бы, но VPN/DPI могли не вернуться автоматически.

## Проверка

- строгий snapshot содержит resume-маркер;
- отложенный background backup не выполняет повторную запись;
- существующее различие strict/best-effort сохранено.

Draft для независимого просмотра перед merge.