### PR TITLE
fix: verify OTA resume journal persistence

### DIFF
--- a/src/lib/update-modal.js
+++ b/src/lib/update-modal.js
@@ -23,6 +23,15 @@ export function buildUpdateJournal({ targetVersion, stage, sourceFingerprint, mo
   };
 }
 
+export function persistUpdateJournal(journal, storage = localStorage) {
+  const encoded = JSON.stringify(journal);
+  storage.setItem("ninety.update.resume", encoded);
+  if (storage.getItem("ninety.update.resume") !== encoded) {
+    throw new Error("OTA resume journal verification failed");
+  }
+  return encoded;
+}
+
 export function resumeRuntimeReady(resume, { vpnReady, dpiReady }) {
   const desired = resume?.schemaVersion === 2 ? resume.desired : resume;
   return (!desired?.vpn || vpnReady === true) && (!desired?.dpi || dpiReady === true);
@@ -206,7 +215,7 @@ export function openUpdateModal(update, opts = {}) {
           dpi: dpiWasOn,
           attempts: journalAttempt,
         });
-        try { localStorage.setItem("ninety.update.resume", JSON.stringify(journal)); } catch {}
+        persistUpdateJournal(journal);
       };
 
       // Гасим ядра ПЕРЕД установкой, но ПОСЛЕ скачивания: разлоченные бинарники

--- a/tests/update-journal.test.mjs
+++ b/tests/update-journal.test.mjs
@@ -2,7 +2,12 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 
 globalThis.window = {};
-const { buildUpdateJournal, portableReleaseUrl, resumeRuntimeReady } = await import("/lib/update-modal.js");
+const {
+  buildUpdateJournal,
+  persistUpdateJournal,
+  portableReleaseUrl,
+  resumeRuntimeReady,
+} = await import("/lib/update-modal.js");
 
 test("portable release URL targets the exact encoded tag", () => {
   assert.equal(
@@ -22,6 +27,29 @@ test("OTA journal versioned и хранит fingerprint/mode/desired state", () 
   assert.equal(j.stage, "runtime_stopped");
   assert.deepEqual(j.desired, { vpn: true, dpi: true });
   assert.equal(j.attempts, 2);
+});
+
+test("OTA journal persistence is verified before runtime shutdown", () => {
+  const data = new Map();
+  const storage = {
+    setItem: (key, value) => data.set(key, String(value)),
+    getItem: (key) => data.get(key) ?? null,
+  };
+  const journal = buildUpdateJournal({ stage: "backup_ready", vpn: true, dpi: false });
+  const encoded = persistUpdateJournal(journal, storage);
+  assert.equal(storage.getItem("ninety.update.resume"), encoded);
+});
+
+test("OTA journal storage failures abort instead of being ignored", () => {
+  const journal = buildUpdateJournal({ stage: "backup_ready", vpn: true, dpi: false });
+  assert.throws(() => persistUpdateJournal(journal, {
+    setItem: () => { throw new Error("quota exceeded"); },
+    getItem: () => null,
+  }), /quota exceeded/);
+  assert.throws(() => persistUpdateJournal(journal, {
+    setItem: () => {},
+    getItem: () => "truncated",
+  }), /verification failed/);
 });
 
 test("UAC cancel / неготовый VPN не разрешает удалить resume journal", () => {


### PR DESCRIPTION
Adds verified persistence for the update resume journal and regression tests. The update now stops before runtime shutdown when storage write or read-back verification fails.