### PR TITLE
fix: align backup envelope validation

### DIFF
--- a/src-tauri/src/backup.rs
+++ b/src-tauri/src/backup.rs
@@ -63,8 +63,9 @@ pub fn state_backup_save(app: AppHandle, json: String) -> Result<(), String> {
 fn snapshot_keys(value: &serde_json::Value) -> Option<&serde_json::Map<String, serde_json::Value>> {
     let root = value.as_object()?;
     match root.get("keys") {
+        None => Some(root),
         Some(serde_json::Value::Object(keys)) => Some(keys),
-        _ => Some(root),
+        Some(_) => None,
     }
 }
 
@@ -241,6 +242,19 @@ mod tests {
         })
         .to_string();
         assert!(valid_snapshot_json(wrapped).is_some());
+    }
+
+    #[test]
+    fn malformed_keys_wrapper_is_rejected() {
+        let wrapped = serde_json::json!({
+            "keys": [],
+            "__schemaVersion": 2,
+            "ninety.options.v1": "{}",
+            "ninety.profiles.v1": "[]",
+            "ninety.subscriptions.v1": "[]"
+        })
+        .to_string();
+        assert!(valid_snapshot_json(wrapped).is_none());
     }
 
     #[test]

--- a/src/lib/state-backup.js
+++ b/src/lib/state-backup.js
@@ -84,6 +84,13 @@ export function backupSoon(delayMs = 5000) {
   backupTimer = setTimeout(() => { backupTimer = null; backupNow(); }, delayMs);
 }
 
+export function unwrapSnapshotEnvelope(parsed) {
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return parsed;
+  if (!Object.prototype.hasOwnProperty.call(parsed, "keys")) return parsed;
+  const keys = parsed.keys;
+  return keys && typeof keys === "object" && !Array.isArray(keys) ? keys : null;
+}
+
 // true → ключи восстановлены; вызывающий делает location.reload(), чтобы все
 // модули перечитали localStorage с нуля (тема/язык/опции читаются при загрузке).
 export async function restoreIfEmpty() {
@@ -99,7 +106,7 @@ export async function restoreIfEmpty() {
   if (!raw) return false;
   let parsed;
   try { parsed = JSON.parse(raw); } catch { return false; }
-  const snap = parsed?.keys && typeof parsed.keys === "object" ? parsed.keys : parsed;
+  const snap = unwrapSnapshotEnvelope(parsed);
   if (!validateSnapshot(snap)) return false;
   const entries = Object.entries(snap).filter(([k, v]) =>
     !k.startsWith("__")

--- a/tests/state-backup.test.mjs
+++ b/tests/state-backup.test.mjs
@@ -38,7 +38,13 @@ globalThis.window = {
   },
 };
 
-const { backupForUpdate, backupNow, restoreIfEmpty, validateSnapshot } = await import("/lib/state-backup.js");
+const {
+  backupForUpdate,
+  backupNow,
+  restoreIfEmpty,
+  unwrapSnapshotEnvelope,
+  validateSnapshot,
+} = await import("/lib/state-backup.js");
 
 test("обычный backup остаётся best-effort, а OTA backup пробрасывает ошибку записи", async () => {
   localStorage.clear();
@@ -110,6 +116,19 @@ test("дисковый снимок сохраняет активный исто
   assert.equal(localStorage.getItem("ninety.subscriptions.active"), "sub-last");
   assert.equal(JSON.parse(localStorage.getItem("ninety.proxy.selection.v1"))["sub:sub-last"], "node-last");
   assert.equal(localStorage.getItem("ninety.dpi.enabled"), "true");
+});
+
+test("backup envelope принимает только object в поле keys", () => {
+  const keys = {
+    __schemaVersion: 2,
+    "ninety.options.v1": "{}",
+    "ninety.profiles.v1": "[]",
+    "ninety.subscriptions.v1": "[]",
+  };
+  assert.equal(unwrapSnapshotEnvelope(keys), keys);
+  assert.equal(unwrapSnapshotEnvelope({ keys }), keys);
+  assert.equal(unwrapSnapshotEnvelope({ keys: [] }), null);
+  assert.equal(unwrapSnapshotEnvelope({ keys: "invalid" }), null);
 });
 
 test("partial/corrupt backup отклоняется до записи", () => {


### PR DESCRIPTION
Makes Rust and frontend use the same `{ keys: object }` contract. A present but non-object `keys` value is rejected instead of falling back to the root snapshot, allowing `.bak` recovery. Includes Rust and JS regression tests.