### PR TITLE
fix: make OTA recovery phase-aware

### DIFF
--- a/src/lib/update-modal.js
+++ b/src/lib/update-modal.js
@@ -4,6 +4,7 @@
 import { t } from "/lib/i18n/index.js";
 
 const SKIP_KEY = "ninety.update.skip";
+const RESUME_KEY = "ninety.update.resume";
 const RELEASE_BASE_URL = "https://github.com/pathetixx/190x4-Ninety/releases/tag";
 
 export function portableReleaseUrl(version) {
@@ -25,16 +26,50 @@ export function buildUpdateJournal({ targetVersion, stage, sourceFingerprint, mo
 
 export function persistUpdateJournal(journal, storage = localStorage) {
   const encoded = JSON.stringify(journal);
-  storage.setItem("ninety.update.resume", encoded);
-  if (storage.getItem("ninety.update.resume") !== encoded) {
+  storage.setItem(RESUME_KEY, encoded);
+  if (storage.getItem(RESUME_KEY) !== encoded) {
     throw new Error("OTA resume journal verification failed");
   }
   return encoded;
 }
 
-export function resumeRuntimeReady(resume, { vpnReady, dpiReady }) {
+export function clearUpdateJournal(storage = localStorage) {
+  storage.removeItem(RESUME_KEY);
+  if (storage.getItem(RESUME_KEY) !== null) {
+    throw new Error("OTA resume journal cleanup verification failed");
+  }
+}
+
+export function resumeRuntimeReady(resume, { vpnReady, dpiReady }, storage = globalThis.localStorage) {
   const desired = resume?.schemaVersion === 2 ? resume.desired : resume;
-  return (!desired?.vpn || vpnReady === true) && (!desired?.dpi || dpiReady === true);
+  const ready = (!desired?.vpn || vpnReady === true) && (!desired?.dpi || dpiReady === true);
+  if (!ready || !storage) return ready;
+  try {
+    if (storage.getItem(RESUME_KEY) != null) clearUpdateJournal(storage);
+    return true;
+  } catch (e) {
+    console.warn("OTA resume journal cleanup failed", e);
+    return false;
+  }
+}
+
+export async function updateRecoveryRequired(journal, invoke, runtimeStopAttempted = false) {
+  if (!journal || !runtimeStopAttempted || typeof invoke !== "function") return false;
+  const desired = journal?.schemaVersion === 2 ? journal.desired : journal;
+  try {
+    const snapshot = desired?.vpn ? await invoke("runtime_snapshot") : null;
+    const vpnReady = !desired?.vpn || (
+      snapshot?.running === true
+      && snapshot?.clashReady !== false
+      && snapshot?.sidecars?.xray !== "died"
+      && snapshot?.sidecars?.clients !== "died"
+    );
+    const dpiReady = !desired?.dpi || !!(await invoke("dpi_running"));
+    return !(vpnReady && dpiReady);
+  } catch {
+    // После начатой остановки неизвестное состояние нельзя выдавать за рабочее.
+    return true;
+  }
 }
 
 function $(id) { return document.getElementById(id); }
@@ -200,8 +235,9 @@ export function openUpdateModal(update, opts = {}) {
       let vpnWasOn = false;
       if (invoke) { try { vpnWasOn = !!(await invoke("singbox_running")); } catch {} }
       let journal = null;
+      let runtimeStopAttempted = false;
       const journalAttempt = (() => {
-        try { return (Number(JSON.parse(localStorage.getItem("ninety.update.resume") || "null")?.attempts) || 0) + 1; }
+        try { return (Number(JSON.parse(localStorage.getItem(RESUME_KEY) || "null")?.attempts) || 0) + 1; }
         catch { return 1; }
       })();
       const writeResume = (stage) => {
@@ -218,6 +254,33 @@ export function openUpdateModal(update, opts = {}) {
         persistUpdateJournal(journal);
       };
 
+      const recoverOrCloseJournal = async (error) => {
+        if (!journal) return false;
+        const needsRecovery = await updateRecoveryRequired(journal, invoke, runtimeStopAttempted);
+        if (!needsRecovery) {
+          clearUpdateJournal();
+          return true;
+        }
+
+        // Recovery получает journal аргументом, поэтому marker можно закрыть до
+        // хука. Тогда main.js::markUpdateRuntimeReady зафиксирует его отсутствие
+        // через state-backup. При провале recovery marker возвращаем.
+        let markerCleared = false;
+        try {
+          clearUpdateJournal();
+          markerCleared = true;
+        } catch (clearError) {
+          console.warn("OTA resume journal pre-recovery cleanup failed", clearError);
+        }
+        let recovered = false;
+        try { recovered = (await opts.onRecovery?.(journal, error)) === true; }
+        catch (recoveryError) { console.warn("update recovery failed", recoveryError); }
+        if (!recovered && markerCleared) persistUpdateJournal(journal);
+        if (!recovered) return false;
+        try { return localStorage.getItem(RESUME_KEY) === null; }
+        catch { return false; }
+      };
+
       // Гасим ядра ПЕРЕД установкой, но ПОСЛЕ скачивания: разлоченные бинарники
       // нужны NSIS только на этапе install, а пока качаем — туннель жив (и
       // download через check({proxy}) идёт по нему; гасить раньше = качать
@@ -228,6 +291,7 @@ export function openUpdateModal(update, opts = {}) {
       const stopEngines = async () => {
         opts.onBeforeRuntimeStop?.();
         if (!invoke) return null;
+        runtimeStopAttempted = true;
         const result = await invoke("stop_singbox");
         if (!result || result.portsReleased === false
           || result.processesExited === false
@@ -301,7 +365,7 @@ export function openUpdateModal(update, opts = {}) {
           console.warn("relaunch failed, running recovery", e);
           writeResume("relaunch_failed");
           let recovered = false;
-          try { recovered = (await opts.onRecovery?.(journal, e)) === true; }
+          try { recovered = await recoverOrCloseJournal(e); }
           catch (recoveryError) { console.warn("relaunch recovery failed", recoveryError); }
           installing = false;
           opts.onInstalling?.(false);
@@ -326,9 +390,10 @@ export function openUpdateModal(update, opts = {}) {
         installBtn.addEventListener("click", close, { once: true });
       } catch (e) {
         console.error("update failed", e);
-        // Journal сохраняется до подтверждённого RuntimeReady: при ошибке
-        // восстанавливаем сессию сейчас либо честно остаёмся выключенными.
-        try { await opts.onRecovery?.(journal, e); } catch (recoveryError) {
+        // До остановки runtime рабочую сессию не трогаем и закрываем только
+        // незавершённый OTA marker. После начатого stop recovery запускается лишь
+        // когда желаемые движки реально уже не готовы.
+        try { await recoverOrCloseJournal(e); } catch (recoveryError) {
           console.warn("update recovery failed", recoveryError);
         }
         installing = false;

--- a/tests/update-journal.test.mjs
+++ b/tests/update-journal.test.mjs
@@ -4,10 +4,21 @@ import assert from "node:assert/strict";
 globalThis.window = {};
 const {
   buildUpdateJournal,
+  clearUpdateJournal,
   persistUpdateJournal,
   portableReleaseUrl,
   resumeRuntimeReady,
+  updateRecoveryRequired,
 } = await import("/lib/update-modal.js");
+
+function makeStorage(initial = {}) {
+  const data = new Map(Object.entries(initial));
+  return {
+    setItem: (key, value) => data.set(key, String(value)),
+    getItem: (key) => data.get(key) ?? null,
+    removeItem: (key) => data.delete(key),
+  };
+}
 
 test("portable release URL targets the exact encoded tag", () => {
   assert.equal(
@@ -30,11 +41,7 @@ test("OTA journal versioned и хранит fingerprint/mode/desired state", () 
 });
 
 test("OTA journal persistence is verified before runtime shutdown", () => {
-  const data = new Map();
-  const storage = {
-    setItem: (key, value) => data.set(key, String(value)),
-    getItem: (key) => data.get(key) ?? null,
-  };
+  const storage = makeStorage();
   const journal = buildUpdateJournal({ stage: "backup_ready", vpn: true, dpi: false });
   const encoded = persistUpdateJournal(journal, storage);
   assert.equal(storage.getItem("ninety.update.resume"), encoded);
@@ -52,8 +59,53 @@ test("OTA journal storage failures abort instead of being ignored", () => {
   }), /verification failed/);
 });
 
-test("UAC cancel / неготовый VPN не разрешает удалить resume journal", () => {
-  const j = buildUpdateJournal({ stage: "installing", vpn: true, dpi: false });
-  assert.equal(resumeRuntimeReady(j, { vpnReady: false, dpiReady: true }), false);
-  assert.equal(resumeRuntimeReady(j, { vpnReady: true, dpiReady: true }), true);
+test("OTA journal cleanup is verified instead of silently succeeding", () => {
+  const storage = makeStorage({ "ninety.update.resume": "journal" });
+  clearUpdateJournal(storage);
+  assert.equal(storage.getItem("ninety.update.resume"), null);
+
+  assert.throws(() => clearUpdateJournal({
+    removeItem: () => {},
+    getItem: () => "journal",
+  }), /cleanup verification failed/);
+});
+
+test("RuntimeReady closes resume marker only after both desired runtimes are ready", () => {
+  const journal = buildUpdateJournal({ stage: "installing", vpn: true, dpi: false });
+  const storage = makeStorage({ "ninety.update.resume": JSON.stringify(journal) });
+  assert.equal(resumeRuntimeReady(journal, { vpnReady: false, dpiReady: true }, storage), false);
+  assert.notEqual(storage.getItem("ninety.update.resume"), null);
+  assert.equal(resumeRuntimeReady(journal, { vpnReady: true, dpiReady: true }, storage), true);
+  assert.equal(storage.getItem("ninety.update.resume"), null);
+});
+
+test("RuntimeReady does not report success when resume marker cannot be removed", () => {
+  const journal = buildUpdateJournal({ stage: "installing", vpn: true, dpi: false });
+  const storage = {
+    removeItem: () => {},
+    getItem: () => JSON.stringify(journal),
+  };
+  assert.equal(resumeRuntimeReady(journal, { vpnReady: true, dpiReady: true }, storage), false);
+});
+
+test("OTA recovery is skipped while the original runtime is still healthy", async () => {
+  const journal = buildUpdateJournal({ stage: "backup_ready", vpn: true, dpi: true });
+  const healthyInvoke = async (command) => {
+    if (command === "runtime_snapshot") {
+      return { running: true, clashReady: true, sidecars: { xray: "alive", clients: "alive" } };
+    }
+    if (command === "dpi_running") return true;
+    throw new Error(`unexpected command: ${command}`);
+  };
+  assert.equal(await updateRecoveryRequired(journal, healthyInvoke, false), false);
+  assert.equal(await updateRecoveryRequired(journal, healthyInvoke, true), false);
+});
+
+test("OTA recovery is required after shutdown or uncertain runtime state", async () => {
+  const journal = buildUpdateJournal({ stage: "runtime_stopped", vpn: true, dpi: false });
+  assert.equal(await updateRecoveryRequired(journal, async (command) => {
+    if (command === "runtime_snapshot") return { running: false, clashReady: false };
+    throw new Error(`unexpected command: ${command}`);
+  }, true), true);
+  assert.equal(await updateRecoveryRequired(journal, async () => { throw new Error("IPC failed"); }, true), true);
 });


### PR DESCRIPTION
## Что исправлено

- ошибки до фактической остановки runtime больше не запускают повторный connect поверх живого VPN;
- состояние runtime перепроверяется через `runtime_snapshot`/`dpi_running` после начатого shutdown;
- удаление `ninety.update.resume` теперь подтверждается обратным чтением;
- RuntimeReady не считается успешным, пока resume-marker реально не удалён;
- перед recovery marker закрывается, чтобы `state-backup` зафиксировал его отсутствие; при неуспешном recovery журнал восстанавливается.

## Проверки

- добавлены unit-тесты на verified cleanup;
- добавлены тесты RuntimeReady;
- добавлены тесты phase-aware recovery для живого, остановленного и неопределённого runtime;
- полный workflow `Checks` пройден.