### PR TITLE
feat: add Kintsugi, Aurora, Porcelain and Titanium themes

### DIFF
--- a/src/lib/themes.js
+++ b/src/lib/themes.js
@@ -88,6 +88,34 @@ export const THEMES = [
     accent: "#FF3355",
     glow: "rgba(255,45,70,0.45)",
   },
+  {
+    id: "kintsugi",
+    name: "Kintsugi Noir",
+    kicker: "LACQUER · GOLD",
+    accent: "#E84D5B",
+    glow: "rgba(232,77,91,0.38)",
+  },
+  {
+    id: "aurora",
+    name: "Aurora Glass",
+    kicker: "AURORA · GLASS",
+    accent: "#59F4E6",
+    glow: "rgba(89,244,230,0.42)",
+  },
+  {
+    id: "porcelain",
+    name: "Porcelain Zero",
+    kicker: "PORCELAIN · INK",
+    accent: "#C94246",
+    glow: "rgba(201,66,70,0.18)",
+  },
+  {
+    id: "titanium",
+    name: "Titanium Signal",
+    kicker: "TITANIUM · SIGNAL",
+    accent: "#4EB8FF",
+    glow: "rgba(78,184,255,0.34)",
+  },
 ];
 
 export function themeIds() {

--- a/src/styles/premium-theme-aurora.css
+++ b/src/styles/premium-theme-aurora.css
@@ -1,0 +1,75 @@
+/* ══════════════════════════════════════════════════════════════
+   AURORA GLASS — navy glass, cyan signal, indigo secondary light
+   ══════════════════════════════════════════════════════════════ */
+:root[data-theme="aurora"],
+.app[data-theme="aurora"] {
+  color-scheme: dark;
+  --ink-0: #02070D;
+  --ink-1: #071421;
+  --ink-2: #0D2233;
+  --ink-3: #15364B;
+  --ink-4: #204B63;
+  --line-1: rgba(189, 239, 255, 0.045);
+  --line-2: rgba(189, 239, 255, 0.10);
+  --line-3: rgba(189, 239, 255, 0.18);
+  --overlay-1: rgba(213, 249, 255, 0.025);
+  --overlay-2: rgba(213, 249, 255, 0.05);
+  --overlay-3: rgba(213, 249, 255, 0.08);
+  --overlay-4: rgba(213, 249, 255, 0.12);
+  --shine-1: rgba(226, 251, 255, 0.06);
+  --shine-2: rgba(226, 251, 255, 0.12);
+  --shadow-strong: rgba(0, 2, 10, 0.80);
+  --text-hi: #EFFCFF;
+  --text-mid: #A7C6D5;
+  --text-lo: #638394;
+  --text-faint: #385568;
+  --accent: #59F4E6;
+  --accent-bright: #A0FFF6;
+  --accent-deep: #168F91;
+  --accent-soft: rgba(89, 244, 230, 0.13);
+  --accent-glow: rgba(89, 244, 230, 0.42);
+  --ok: #59F4E6;
+  --premium-secondary: #8EA7FF;
+  --premium-status: #8CFFF5;
+  --premium-card: linear-gradient(145deg, rgba(17, 43, 62, 0.80), rgba(5, 18, 31, 0.88));
+  --premium-card-hover: linear-gradient(145deg, rgba(24, 57, 80, 0.88), rgba(7, 24, 40, 0.94));
+  --premium-disc: radial-gradient(circle at 50% 42%, #143B50 0%, #071A2A 58%, #020912 100%);
+  --premium-border: rgba(151, 225, 255, 0.20);
+  --premium-shadow: 0 24px 60px -34px rgba(0, 0, 0, 0.86), inset 0 1px rgba(226, 251, 255, 0.10);
+  --premium-mask-idle: hue-rotate(142deg) saturate(0.92) brightness(0.88) contrast(1.08);
+  --premium-mask-secured: hue-rotate(142deg) saturate(1.18) brightness(1.08) contrast(1.04) drop-shadow(0 0 16px rgba(89, 244, 230, 0.30));
+  --sidebar-surface-top: rgba(11, 31, 47, 0.95);
+  --sidebar-surface-bottom: rgba(3, 13, 22, 0.98);
+  --sidebar-row-start: rgba(4, 17, 29, 0.93);
+  --sidebar-row-middle: rgba(9, 29, 45, 0.94);
+  --sidebar-row-hover: rgba(15, 46, 67, 0.96);
+  --sidebar-row-active: rgba(18, 62, 84, 0.96);
+  --sidebar-border-soft: rgba(151, 225, 255, 0.07);
+  --sidebar-border-strong: rgba(151, 225, 255, 0.14);
+  --sidebar-text: #9AB7C8;
+  --sidebar-text-active: #F3FDFF;
+  --sidebar-mark-filter: hue-rotate(142deg) saturate(1.0) brightness(1.02) contrast(1.04) drop-shadow(0 0 18px rgba(89,244,230,.20));
+  --edge-top: linear-gradient(180deg, rgba(226,251,255,0.12), rgba(226,251,255,0) 58%);
+}
+
+html[data-theme="aurora"] .app::before {
+  background:
+    radial-gradient(ellipse 62% 38% at 78% 18%, rgba(142, 167, 255, 0.18), transparent 68%),
+    radial-gradient(ellipse 54% 42% at 66% 72%, rgba(89, 244, 230, 0.14), transparent 66%),
+    radial-gradient(ellipse 38% 28% at 96% 55%, rgba(206, 112, 255, 0.10), transparent 70%),
+    linear-gradient(150deg, #02070D, #061323 54%, #02070D);
+}
+html[data-theme="aurora"] .app::after { opacity: 0.035; }
+html[data-theme="aurora"] .sidebar {
+  backdrop-filter: blur(18px) saturate(1.08);
+}
+html[data-theme="aurora"] .sidebar::before {
+  opacity: 0.30;
+  background:
+    radial-gradient(ellipse at 18% 8%, rgba(89, 244, 230, 0.15), transparent 28%),
+    radial-gradient(ellipse at 85% 70%, rgba(142, 167, 255, 0.09), transparent 42%);
+}
+html[data-theme="aurora"] .nav__item--active {
+  background: linear-gradient(90deg, rgba(27, 75, 106, 0.70), rgba(35, 109, 136, 0.32));
+  box-shadow: inset 0 1px rgba(226,251,255,.10), inset 0 -1px rgba(89,244,230,.10), 0 0 30px rgba(89,244,230,.04);
+}

--- a/src/styles/premium-theme-kintsugi.css
+++ b/src/styles/premium-theme-kintsugi.css
@@ -1,0 +1,80 @@
+/* ══════════════════════════════════════════════════════════════
+   KINTSUGI NOIR — black lacquer, champagne gold, crimson signal
+   ══════════════════════════════════════════════════════════════ */
+:root[data-theme="kintsugi"],
+.app[data-theme="kintsugi"] {
+  color-scheme: dark;
+  --ink-0: #050404;
+  --ink-1: #0C0909;
+  --ink-2: #171111;
+  --ink-3: #241818;
+  --ink-4: #332020;
+  --line-1: rgba(224, 197, 139, 0.055);
+  --line-2: rgba(224, 197, 139, 0.12);
+  --line-3: rgba(224, 197, 139, 0.22);
+  --overlay-1: rgba(255, 238, 205, 0.025);
+  --overlay-2: rgba(255, 238, 205, 0.05);
+  --overlay-3: rgba(255, 238, 205, 0.08);
+  --overlay-4: rgba(255, 238, 205, 0.13);
+  --shine-1: rgba(255, 235, 196, 0.06);
+  --shine-2: rgba(255, 235, 196, 0.13);
+  --shadow-strong: rgba(0, 0, 0, 0.82);
+  --text-hi: #F5EEE7;
+  --text-mid: #B9AA9D;
+  --text-lo: #786C64;
+  --text-faint: #4B403B;
+  --accent: #E84D5B;
+  --accent-bright: #FF7180;
+  --accent-deep: #7F202B;
+  --accent-soft: rgba(232, 77, 91, 0.14);
+  --accent-glow: rgba(232, 77, 91, 0.38);
+  --ok: #E84D5B;
+  --warn: #D8B56B;
+  --premium-secondary: #D8B56B;
+  --premium-status: #E5C887;
+  --premium-card: linear-gradient(180deg, rgba(31, 22, 20, 0.96), rgba(10, 8, 8, 0.98));
+  --premium-card-hover: linear-gradient(180deg, rgba(42, 28, 25, 0.98), rgba(15, 10, 10, 0.99));
+  --premium-disc: radial-gradient(circle at 50% 42%, #241A16 0%, #0E0A09 58%, #050404 100%);
+  --premium-border: rgba(216, 181, 107, 0.24);
+  --premium-shadow: 0 18px 48px -30px rgba(0, 0, 0, 0.94), inset 0 1px rgba(255, 235, 196, 0.06);
+  --premium-mask-idle: sepia(0.38) saturate(0.78) brightness(0.88) contrast(1.12);
+  --premium-mask-secured: sepia(0.48) saturate(0.88) brightness(1.02) contrast(1.1) drop-shadow(0 0 14px rgba(232, 77, 91, 0.28));
+  --sidebar-surface-top: #15100F;
+  --sidebar-surface-bottom: #070505;
+  --sidebar-row-start: #090707;
+  --sidebar-row-middle: #100C0B;
+  --sidebar-row-hover: #1A1211;
+  --sidebar-row-active: #2A1517;
+  --sidebar-border-soft: rgba(216, 181, 107, 0.09);
+  --sidebar-border-strong: rgba(216, 181, 107, 0.17);
+  --sidebar-text: #A99889;
+  --sidebar-text-active: #F5EEE7;
+  --sidebar-mark-filter: sepia(0.55) saturate(0.8) brightness(0.92) contrast(1.08) drop-shadow(0 8px 18px rgba(0,0,0,.8));
+  --edge-top: linear-gradient(180deg, rgba(255, 232, 190, 0.09) 0%, rgba(255, 232, 190, 0) 58%);
+}
+
+html[data-theme="kintsugi"] .app::before {
+  background:
+    linear-gradient(118deg, transparent 0 25%, rgba(216, 181, 107, 0.08) 25.12%, transparent 25.32% 100%),
+    linear-gradient(64deg, transparent 0 70%, rgba(216, 181, 107, 0.055) 70.12%, transparent 70.32% 100%),
+    radial-gradient(ellipse 76% 64% at 64% 116%, rgba(232, 77, 91, 0.12), transparent 68%),
+    radial-gradient(circle at 85% 12%, rgba(216, 181, 107, 0.055), transparent 25%),
+    #050404;
+}
+html[data-theme="kintsugi"] .app::after { opacity: 0.075; }
+html[data-theme="kintsugi"] .sidebar::before {
+  opacity: 0.42;
+  background:
+    linear-gradient(132deg, transparent 0 43%, rgba(216, 181, 107, 0.10) 43.15%, transparent 43.35%),
+    repeating-linear-gradient(115deg, transparent 0 39px, rgba(216, 181, 107, 0.025) 40px, transparent 41px 79px);
+}
+html[data-theme="kintsugi"] .nav__item--active {
+  background:
+    linear-gradient(90deg, rgba(88, 27, 34, 0.30), rgba(232, 77, 91, 0.12) 72%, rgba(216, 181, 107, 0.06)),
+    #130C0C;
+  border-color: rgba(216, 181, 107, 0.18);
+}
+html[data-theme="kintsugi"] .hero[data-state="secured"] .hero__title {
+  color: var(--premium-status);
+  text-shadow: 0 0 18px rgba(216, 181, 107, 0.18), 0 0 42px rgba(232, 77, 91, 0.12);
+}

--- a/src/styles/premium-theme-porcelain.css
+++ b/src/styles/premium-theme-porcelain.css
@@ -1,0 +1,90 @@
+/* ══════════════════════════════════════════════════════════════
+   PORCELAIN ZERO — warm ceramic, ink, vermilion, aged gold
+   ══════════════════════════════════════════════════════════════ */
+:root[data-theme="porcelain"],
+.app[data-theme="porcelain"] {
+  color-scheme: light;
+  --ink-0: #F1ECE3;
+  --ink-1: #FBF8F1;
+  --ink-2: #E8E1D6;
+  --ink-3: #D9D0C3;
+  --ink-4: #C8BDAE;
+  --line-1: rgba(55, 46, 39, 0.055);
+  --line-2: rgba(55, 46, 39, 0.11);
+  --line-3: rgba(55, 46, 39, 0.18);
+  --overlay-1: rgba(55, 46, 39, 0.025);
+  --overlay-2: rgba(55, 46, 39, 0.045);
+  --overlay-3: rgba(55, 46, 39, 0.07);
+  --overlay-4: rgba(55, 46, 39, 0.11);
+  --shine-1: rgba(255, 255, 255, 0.45);
+  --shine-2: rgba(255, 255, 255, 0.72);
+  --shadow-strong: rgba(73, 59, 46, 0.20);
+  --text-hi: #28231F;
+  --text-mid: #675E56;
+  --text-lo: #94897E;
+  --text-faint: #B8AEA2;
+  --accent: #C94246;
+  --accent-bright: #D9585B;
+  --accent-deep: #842E31;
+  --accent-soft: rgba(201, 66, 70, 0.10);
+  --accent-glow: rgba(201, 66, 70, 0.18);
+  --ok: #C94246;
+  --warn: #A9864D;
+  --err: #B43B3E;
+  --premium-secondary: #A9864D;
+  --premium-status: #28231F;
+  --premium-card: linear-gradient(180deg, rgba(255, 253, 248, 0.96), rgba(239, 233, 224, 0.94));
+  --premium-card-hover: linear-gradient(180deg, #FFFDF8, #EAE2D8);
+  --premium-disc: radial-gradient(circle at 50% 38%, #FFFDF8 0%, #ECE5DB 70%, #DED5C8 100%);
+  --premium-border: rgba(84, 69, 57, 0.14);
+  --premium-shadow: 0 18px 44px -30px rgba(73, 59, 46, 0.32), inset 0 1px rgba(255, 255, 255, 0.72);
+  --premium-mask-idle: grayscale(0.72) sepia(0.08) brightness(0.70) contrast(1.18);
+  --premium-mask-secured: grayscale(0.58) sepia(0.08) brightness(0.78) contrast(1.2) drop-shadow(0 8px 12px rgba(73,59,46,.16));
+  --sidebar-surface-top: #EEE8DE;
+  --sidebar-surface-bottom: #DDD5C8;
+  --sidebar-row-start: rgba(247, 243, 236, 0.88);
+  --sidebar-row-middle: rgba(234, 227, 217, 0.92);
+  --sidebar-row-hover: rgba(224, 214, 202, 0.92);
+  --sidebar-row-active: rgba(249, 239, 235, 0.96);
+  --sidebar-border-soft: rgba(55, 46, 39, 0.075);
+  --sidebar-border-strong: rgba(55, 46, 39, 0.13);
+  --sidebar-text: #6E655D;
+  --sidebar-text-active: #28231F;
+  --sidebar-brand-gradient: linear-gradient(180deg, #342E29, #766A60 52%, #2E2925);
+  --sidebar-brand-stroke: rgba(255,255,255,.35);
+  --sidebar-mark-filter: grayscale(.72) sepia(.08) brightness(.72) contrast(1.22) drop-shadow(0 8px 14px rgba(73,59,46,.16));
+  --edge-top: linear-gradient(180deg, rgba(255,255,255,.70), rgba(255,255,255,0) 62%);
+  --r-sm: 11px;
+  --r-md: 16px;
+  --r-lg: 20px;
+}
+
+html[data-theme="porcelain"] .app::before {
+  background:
+    radial-gradient(circle at 69% 49%, transparent 0 23%, rgba(71, 61, 53, 0.035) 23.2% 23.8%, transparent 24% 31%, rgba(169, 134, 77, 0.035) 31.2% 31.8%, transparent 32%),
+    repeating-linear-gradient(3deg, transparent 0 30px, rgba(71,61,53,.018) 31px, transparent 32px 70px),
+    radial-gradient(ellipse 70% 58% at 62% 106%, rgba(201, 66, 70, 0.055), transparent 68%),
+    #F1ECE3;
+}
+html[data-theme="porcelain"] .app::after { opacity: 0.018; mix-blend-mode: multiply; }
+html[data-theme="porcelain"] .sidebar::before {
+  opacity: 0.22;
+  background:
+    radial-gradient(ellipse at 20% 90%, rgba(70, 62, 55, 0.10), transparent 34%),
+    repeating-linear-gradient(4deg, transparent 0 38px, rgba(70,62,55,.025) 39px, transparent 40px 80px);
+}
+html[data-theme="porcelain"] .nav__item--active {
+  clip-path: none;
+  background: linear-gradient(90deg, rgba(255,255,255,.45), rgba(201,66,70,.055));
+  box-shadow: inset 0 1px rgba(255,255,255,.72), inset 0 -1px rgba(55,46,39,.08);
+}
+html[data-theme="porcelain"] .hero__bloom { filter: blur(54px); }
+html[data-theme="porcelain"] .hero[data-state="secured"] .hero__bloom { opacity: 0.18; }
+html[data-theme="porcelain"] .hero[data-state="secured"] .hero__halo { opacity: 0.28; }
+html[data-theme="porcelain"] .hero[data-state="secured"] .hud { opacity: 0.86 !important; }
+html[data-theme="porcelain"] .hud [data-hud="ca"] { transform: none !important; filter: none !important; }
+html[data-theme="porcelain"] .hud__sys { fill: var(--text-mid); letter-spacing: 1.5px; }
+html[data-theme="porcelain"] .hud__target,
+html[data-theme="porcelain"] .hud__intg { fill: var(--accent-deep); }
+html[data-theme="porcelain"] .hud__clock { fill: var(--text-lo); }
+html[data-theme="porcelain"] .hero[data-state="secured"] .hero__title { text-shadow: none; }

--- a/src/styles/premium-theme-shared.css
+++ b/src/styles/premium-theme-shared.css
@@ -1,0 +1,74 @@
+/* ═════════════════════════════════════════════════════════════
+   Shared premium material layer
+   ══════════════════════════════════════════════════════════════ */
+html:is([data-theme="kintsugi"], [data-theme="aurora"], [data-theme="porcelain"], [data-theme="titanium"]) .sub-card,
+html:is([data-theme="kintsugi"], [data-theme="aurora"], [data-theme="porcelain"], [data-theme="titanium"]) .tool-btn,
+html:is([data-theme="kintsugi"], [data-theme="aurora"], [data-theme="porcelain"], [data-theme="titanium"]) .loc-card,
+html:is([data-theme="kintsugi"], [data-theme="aurora"], [data-theme="porcelain"], [data-theme="titanium"]) .stats,
+html:is([data-theme="kintsugi"], [data-theme="aurora"], [data-theme="porcelain"], [data-theme="titanium"]) .popover,
+html:is([data-theme="kintsugi"], [data-theme="aurora"], [data-theme="porcelain"], [data-theme="titanium"]) .add-modal__card,
+html:is([data-theme="kintsugi"], [data-theme="aurora"], [data-theme="porcelain"], [data-theme="titanium"]) .update-modal__card {
+  background: var(--premium-card);
+  border-color: var(--premium-border);
+  box-shadow: var(--premium-shadow);
+}
+
+html:is([data-theme="kintsugi"], [data-theme="aurora"], [data-theme="porcelain"], [data-theme="titanium"]) .tool-btn:hover,
+html:is([data-theme="kintsugi"], [data-theme="aurora"], [data-theme="porcelain"], [data-theme="titanium"]) .loc-card:hover {
+  background: var(--premium-card-hover);
+  border-color: color-mix(in srgb, var(--premium-border) 72%, var(--accent) 28%);
+}
+
+html:is([data-theme="kintsugi"], [data-theme="aurora"], [data-theme="porcelain"], [data-theme="titanium"]) .hero__disc {
+  background: var(--premium-disc);
+  border-color: var(--premium-border);
+  box-shadow:
+    0 0 0 1px var(--line-1) inset,
+    0 1px 0 var(--shine-2) inset,
+    0 26px 64px -26px var(--shadow-strong),
+    0 0 34px var(--accent-glow);
+}
+html:is([data-theme="kintsugi"], [data-theme="aurora"], [data-theme="porcelain"], [data-theme="titanium"]) .hero__mask {
+  filter: var(--premium-mask-idle);
+}
+html:is([data-theme="kintsugi"], [data-theme="aurora"], [data-theme="porcelain"], [data-theme="titanium"]) .hero[data-state="secured"] .hero__mask {
+  filter: var(--premium-mask-secured);
+}
+
+/* A second HUD material gives these themes a real identity instead of just a new hue. */
+html:is([data-theme="kintsugi"], [data-theme="aurora"], [data-theme="porcelain"], [data-theme="titanium"]) .hud__static > path:nth-of-type(even),
+html:is([data-theme="kintsugi"], [data-theme="aurora"], [data-theme="porcelain"], [data-theme="titanium"]) .hud__outer > line:nth-of-type(6n),
+html:is([data-theme="kintsugi"], [data-theme="aurora"], [data-theme="porcelain"], [data-theme="titanium"]) .hud__ticks > line:nth-of-type(10n) {
+  stroke: var(--premium-secondary);
+}
+html:is([data-theme="kintsugi"], [data-theme="aurora"], [data-theme="porcelain"], [data-theme="titanium"]) .hud__target {
+  fill: var(--premium-secondary);
+}
+
+/* Theme chooser previews: show the material, not only four accent-opacity dots. */
+.theme-card[data-theme="kintsugi"] {
+  background: linear-gradient(145deg, #1D1412, #080606 72%);
+  border-color: rgba(216,181,107,.26);
+}
+.theme-card[data-theme="kintsugi"] .theme-card__kicker { color: #D8B56B; }
+.theme-card[data-theme="aurora"] {
+  background: linear-gradient(145deg, #15344A, #061522 68%, #161B43);
+  border-color: rgba(151,225,255,.24);
+}
+.theme-card[data-theme="aurora"] .theme-card__kicker { color: #8EA7FF; }
+.theme-card[data-theme="porcelain"] {
+  background: linear-gradient(145deg, #FFFDF8, #E8E1D6);
+  border-color: rgba(55,46,39,.16);
+  color: #28231F;
+}
+.theme-card[data-theme="porcelain"] .theme-card__name { color: #28231F; }
+.theme-card[data-theme="porcelain"] .theme-card__kicker { color: #8A7046; }
+.theme-card[data-theme="titanium"] {
+  background:
+    linear-gradient(rgba(199,213,223,.035) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(199,213,223,.035) 1px, transparent 1px),
+    linear-gradient(145deg, #26313B, #0B1117 72%);
+  background-size: 18px 18px, 18px 18px, auto;
+  border-color: rgba(199,213,223,.18);
+}
+.theme-card[data-theme="titanium"] .theme-card__kicker { color: #C7D5DF; }

--- a/src/styles/premium-theme-titanium.css
+++ b/src/styles/premium-theme-titanium.css
@@ -1,0 +1,82 @@
+/* ══════════════════════════════════════════════════════════════
+   TITANIUM SIGNAL — gunmetal instrument panel, precise blue signal
+   ══════════════════════════════════════════════════════════════ */
+:root[data-theme="titanium"],
+.app[data-theme="titanium"] {
+  color-scheme: dark;
+  --ink-0: #070B0F;
+  --ink-1: #0D141B;
+  --ink-2: #17212A;
+  --ink-3: #25323D;
+  --ink-4: #34434F;
+  --line-1: rgba(212, 225, 234, 0.035);
+  --line-2: rgba(212, 225, 234, 0.085);
+  --line-3: rgba(212, 225, 234, 0.15);
+  --overlay-1: rgba(222, 238, 247, 0.02);
+  --overlay-2: rgba(222, 238, 247, 0.045);
+  --overlay-3: rgba(222, 238, 247, 0.075);
+  --overlay-4: rgba(222, 238, 247, 0.12);
+  --shine-1: rgba(232, 244, 251, 0.055);
+  --shine-2: rgba(232, 244, 251, 0.10);
+  --shadow-strong: rgba(0, 0, 0, 0.82);
+  --text-hi: #EDF3F7;
+  --text-mid: #A8B4BD;
+  --text-lo: #687782;
+  --text-faint: #3F4C56;
+  --accent: #4EB8FF;
+  --accent-bright: #8DD2FF;
+  --accent-deep: #17699E;
+  --accent-soft: rgba(78, 184, 255, 0.12);
+  --accent-glow: rgba(78, 184, 255, 0.34);
+  --ok: #5DD58C;
+  --premium-secondary: #C7D5DF;
+  --premium-status: #5DD58C;
+  --premium-card: linear-gradient(150deg, rgba(32, 42, 52, 0.98), rgba(10, 16, 22, 0.99));
+  --premium-card-hover: linear-gradient(150deg, rgba(42, 54, 66, 0.99), rgba(13, 21, 28, 1));
+  --premium-disc: radial-gradient(circle at 48% 38%, #2A3540 0%, #111922 62%, #070B0F 100%);
+  --premium-border: rgba(199, 213, 223, 0.14);
+  --premium-shadow: 0 20px 54px -34px rgba(0,0,0,.94), inset 0 1px rgba(232,244,251,.07);
+  --premium-mask-idle: grayscale(0.72) hue-rotate(168deg) saturate(0.74) brightness(0.82) contrast(1.18);
+  --premium-mask-secured: grayscale(0.52) hue-rotate(168deg) saturate(1.2) brightness(1.03) contrast(1.16) drop-shadow(0 0 15px rgba(78,184,255,.26));
+  --sidebar-surface-top: #1B222A;
+  --sidebar-surface-bottom: #090D12;
+  --sidebar-row-start: #0D1318;
+  --sidebar-row-middle: #151E25;
+  --sidebar-row-hover: #202C35;
+  --sidebar-row-active: #263743;
+  --sidebar-border-soft: rgba(199,213,223,.055);
+  --sidebar-border-strong: rgba(199,213,223,.11);
+  --sidebar-text: #A0ADB6;
+  --sidebar-text-active: #F2F6F8;
+  --sidebar-mark-filter: grayscale(.62) hue-rotate(168deg) saturate(.86) brightness(.92) contrast(1.16) drop-shadow(0 10px 18px rgba(0,0,0,.72));
+  --edge-top: linear-gradient(180deg, rgba(232,244,251,.09), rgba(232,244,251,0) 58%);
+  --r-xs: 4px;
+  --r-sm: 8px;
+  --r-md: 12px;
+  --r-lg: 16px;
+}
+
+html[data-theme="titanium"] .app::before {
+  background:
+    linear-gradient(rgba(117, 143, 158, 0.035) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(117, 143, 158, 0.035) 1px, transparent 1px),
+    repeating-linear-gradient(126deg, transparent 0 31px, rgba(212,225,234,.012) 32px, transparent 33px 65px),
+    radial-gradient(ellipse 68% 54% at 68% 108%, rgba(78, 184, 255, 0.10), transparent 70%),
+    #070B0F;
+  background-size: 48px 48px, 48px 48px, auto, auto, auto;
+}
+html[data-theme="titanium"] .app::after { opacity: 0.045; }
+html[data-theme="titanium"] .sidebar::before {
+  opacity: 0.22;
+  background:
+    repeating-linear-gradient(126deg, transparent 0 28px, rgba(212,225,234,.028) 29px, transparent 30px 58px),
+    linear-gradient(180deg, rgba(255,255,255,.025), transparent 36%);
+}
+html[data-theme="titanium"] .nav__item--active {
+  clip-path: polygon(0 0, calc(100% - 20px) 0, 100% 20px, 100% 100%, 0 100%);
+  background: linear-gradient(90deg, #1A2730, #263A48 64%, #18242C);
+}
+html[data-theme="titanium"] .hero[data-state="secured"] .hero__title {
+  color: var(--premium-status);
+  text-shadow: 0 0 20px rgba(93, 213, 140, 0.18);
+}

--- a/src/styles/premium-themes.css
+++ b/src/styles/premium-themes.css
@@ -1,0 +1,6 @@
+/* Ninety · Premium Theme Collection — loaded after base component styles. */
+@import url("/styles/premium-theme-kintsugi.css");
+@import url("/styles/premium-theme-aurora.css");
+@import url("/styles/premium-theme-porcelain.css");
+@import url("/styles/premium-theme-titanium.css");
+@import url("/styles/premium-theme-shared.css");

--- a/src/styles/rtl.css
+++ b/src/styles/rtl.css
@@ -1,3 +1,5 @@
+@import url("/styles/premium-themes.css");
+
 /* Ninety · RTL — зеркала под [dir="rtl"] (fa/ar). Грузится последним.
    Направленческая вёрстка вынесена в логические свойства (inset-inline-*, margin/
    padding/border-inline-*, text-align:start/end) прямо в каталогах стилей — они

--- a/tests/premium-themes.test.mjs
+++ b/tests/premium-themes.test.mjs
@@ -1,0 +1,54 @@
+// Premium theme collection: registry and material layer stay in sync.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { THEMES } from "/lib/themes.js";
+
+const PREMIUM_THEME_IDS = ["kintsugi", "aurora", "porcelain", "titanium"];
+const style = name => readFileSync(new URL(`../src/styles/${name}`, import.meta.url), "utf8");
+const css = [
+  style("premium-theme-kintsugi.css"),
+  style("premium-theme-aurora.css"),
+  style("premium-theme-porcelain.css"),
+  style("premium-theme-titanium.css"),
+  style("premium-theme-shared.css"),
+].join("\n");
+const manifestCss = style("premium-themes.css");
+const rtlCss = style("rtl.css");
+
+test("premium themes: все четыре темы зарегистрированы", () => {
+  const ids = new Set(THEMES.map(theme => theme.id));
+  for (const id of PREMIUM_THEME_IDS) assert.equal(ids.has(id), true, id);
+});
+
+test("premium themes: manifest подключает все material styles", () => {
+  for (const id of [...PREMIUM_THEME_IDS, "shared"]) {
+    assert.match(manifestCss, new RegExp(`premium-theme-${id}\\.css`));
+  }
+  assert.match(rtlCss, /^@import url\(["']\/styles\/premium-themes\.css["']\);/);
+});
+
+test("premium themes: каждая тема имеет material tokens и preview", () => {
+  for (const id of PREMIUM_THEME_IDS) {
+    assert.match(css, new RegExp(`data-theme=["']${id}["']`));
+    assert.match(css, new RegExp(`\\.theme-card\\[data-theme=["']${id}["']\\]`));
+  }
+
+  for (const token of [
+    "--premium-secondary",
+    "--premium-status",
+    "--premium-card",
+    "--premium-card-hover",
+    "--premium-disc",
+    "--premium-border",
+    "--premium-shadow",
+    "--premium-mask-idle",
+    "--premium-mask-secured",
+  ]) {
+    assert.match(css, new RegExp(`${token}:`));
+  }
+});
+
+test("premium themes: porcelain отключает тяжёлый glitch transform", () => {
+  assert.match(css, /data-theme="porcelain"[^}]*[\s\S]*?\[data-hud="ca"\][^{]*\{[^}]*transform:\s*none\s*!important/);
+});


### PR DESCRIPTION
## Summary

Adds four premium appearance themes to Ninety and makes them materially distinct instead of limiting them to accent-color swaps.

### New themes

- **Kintsugi Noir** — black Japanese lacquer, champagne-gold seams and controlled crimson signal lighting.
- **Aurora Glass** — deep navy glass, cyan connection signal and indigo/violet secondary HUD light.
- **Porcelain Zero** — a true warm light theme with ceramic surfaces, ink-like neutrals, vermilion and aged gold.
- **Titanium Signal** — gunmetal instrument-panel styling, blueprint grid details and precise blue signal accents.

## Implementation

- registers all four themes in the shared `THEMES` registry, so main UI, onboarding and appearance settings use the same source of truth;
- adds per-theme material tokens for cards, hero disc, borders, shadows, mask treatment, status color and secondary HUD color;
- adds a shared premium material layer for subscription/location cards, telemetry, tool buttons, popovers and update/add-profile modals;
- adds dedicated theme previews in the appearance grid;
- loads the collection after the existing component styles while preserving RTL overrides;
- disables the heavy chromatic glitch treatment for the light Porcelain theme;
- adds regression tests for registration, stylesheet wiring, material tokens and previews.

## Validation

- premium theme tests: **4 passed, 0 failed**;
- JavaScript syntax check passed for the updated registry and test file;
- CSS files were checked for balanced blocks, required selectors/tokens and UTF-8 readability;
- branch is one commit ahead of `main` with no unrelated changes.

Full repository CI is expected to run on this pull request.