### PR TITLE
perf: pause visual activity while hidden in tray

### DIFF
--- a/src/lib/activity-controller.js
+++ b/src/lib/activity-controller.js
@@ -1,0 +1,97 @@
+// Ninety · foreground/background activity controller.
+//
+// Visual modules subscribe to this store instead of running independent work
+// while WebView2 is hidden in the tray. Network safety watchdogs remain outside
+// this controller and continue to run regardless of window visibility.
+
+import { perfObserver } from "/lib/performance-observer.js";
+
+function readVisible(doc) {
+  return !doc || doc.visibilityState !== "hidden";
+}
+
+export function createActivityController({
+  document: doc = globalThis.document,
+  window: win = globalThis.window,
+  initialView = "home",
+} = {}) {
+  let state = Object.freeze({
+    visible: readVisible(doc),
+    focused: typeof doc?.hasFocus === "function" ? !!doc.hasFocus() : true,
+    view: initialView,
+  });
+  const listeners = new Set();
+  let mounted = false;
+
+  function notify(previous) {
+    perfObserver.gauge("activity.visible", state.visible ? 1 : 0);
+    perfObserver.gauge("activity.focused", state.focused ? 1 : 0);
+    for (const listener of [...listeners]) {
+      try { listener(state, previous); } catch (error) {
+        console.warn("activity listener failed", error);
+      }
+    }
+  }
+
+  function patch(next) {
+    const candidate = { ...state, ...next };
+    if (candidate.visible === state.visible
+      && candidate.focused === state.focused
+      && candidate.view === state.view) return state;
+    const previous = state;
+    state = Object.freeze(candidate);
+    notify(previous);
+    return state;
+  }
+
+  const onVisibility = () => patch({ visible: readVisible(doc) });
+  const onFocus = () => patch({ focused: true });
+  const onBlur = () => patch({ focused: false });
+
+  function mount() {
+    if (mounted) return;
+    mounted = true;
+    doc?.addEventListener?.("visibilitychange", onVisibility);
+    win?.addEventListener?.("focus", onFocus);
+    win?.addEventListener?.("blur", onBlur);
+    notify(state);
+  }
+
+  function destroy() {
+    if (!mounted) return;
+    mounted = false;
+    doc?.removeEventListener?.("visibilitychange", onVisibility);
+    win?.removeEventListener?.("focus", onFocus);
+    win?.removeEventListener?.("blur", onBlur);
+    listeners.clear();
+  }
+
+  function subscribe(listener, { immediate = true } = {}) {
+    if (typeof listener !== "function") return () => {};
+    listeners.add(listener);
+    if (immediate) listener(state, state);
+    return () => listeners.delete(listener);
+  }
+
+  function setView(view) {
+    if (typeof view === "string" && view) patch({ view });
+  }
+
+  function isInteractive(view = null) {
+    return state.visible && state.focused && (!view || state.view === view);
+  }
+
+  return {
+    mount,
+    destroy,
+    subscribe,
+    setView,
+    snapshot: () => state,
+    isVisible: () => state.visible,
+    isFocused: () => state.focused,
+    isInteractive,
+  };
+}
+
+export const activityController = createActivityController();
+activityController.mount();

--- a/src/lib/hero-hud.js
+++ b/src/lib/hero-hud.js
@@ -7,13 +7,13 @@
 //      clock y=60→106, INTEGRITY y=330→298, ERR y=350→372.  (раньше всё было свалено
 //      в один 20px-пятак внизу + часы лезли на дугу SYSTEM STATUS).
 //   2) Анимация HUD больше НЕ глушится prefers-reduced-motion: вращение колец, глитч,
-//      INTEGRITY/ERR/blink работают всегда. HUD — смысловой центр экрана, а не декор;
-//      при выключенных в Windows анимациях он раньше полностью замерзал (играла только
-//      видео-маска). Если нужна строгая a11y — погасите .hud__outer/seg/ticks в app.css.
+//      INTEGRITY/ERR/blink работают всегда, пока окно действительно видно. В трее
+//      визуальная телеметрия полностью ставится на паузу через activity-controller.
 //   3) Вращение колец перенесено с rAF+setAttribute('transform') на CSS-анимацию,
 //      идущую на компоновщике (GPU): слой растрится один раз, дальше только крутится.
-//      Это убирает покадровую перерисовку всего SVG (была причина высокой нагрузки на
-//      GPU-процесс WebView2 на главном экране). Скорости/направления не изменились.
+
+import { activityController } from "/lib/activity-controller.js";
+import { perfObserver } from "/lib/performance-observer.js";
 
 const CX = 200, CY = 200;
 const P = (deg, r) => [CX + Math.cos((deg * Math.PI) / 180) * r, CY + Math.sin((deg * Math.PI) / 180) * r];
@@ -96,14 +96,23 @@ const ERR_OFFLINE = ["NO LINK", "SEARCHING…", "ERR_ON_KNW"];
 const pad = (n) => String(n).padStart(2, "0");
 
 // getState() → 'secured' | 'linking' | 'standby'.  getTarget() → строка-тег сервера или null.
-export function initHeroHud(svg, { getState, getTarget } = {}) {
+export function initHeroHud(svg, { getState, getTarget, activity = activityController } = {}) {
   if (!svg) return { destroy() {} };
   svg.innerHTML = buildHud();
   const els = {};
   svg.querySelectorAll("[data-hud]").forEach((el) => { els[el.dataset.hud] = el; });
 
   const st = () => (getState?.() || "standby");
-  let timers = [], intgVal = 0, ei = 0, clockStr = "";
+  let timers = [], transientTimers = [], intgVal = 0, ei = 0, clockStr = "";
+  let running = false;
+
+  function later(fn, ms) {
+    const id = setTimeout(() => {
+      transientTimers = transientTimers.filter((value) => value !== id);
+      if (running) fn();
+    }, ms);
+    transientTimers.push(id);
+  }
 
   function updClock() {
     const d = new Date();
@@ -121,7 +130,7 @@ export function initHeroHud(svg, { getState, getTarget } = {}) {
   function blink() {
     if (!els.sys) return;
     els.sys.setAttribute("opacity", "0.18");
-    setTimeout(() => els.sys && els.sys.setAttribute("opacity", "1"), 105);
+    later(() => els.sys?.setAttribute("opacity", "1"), 105);
   }
   function cycleErr() {
     if (!els.err) return;
@@ -132,15 +141,13 @@ export function initHeroHud(svg, { getState, getTarget } = {}) {
     els.err.style.fill = sec ? "var(--text-lo)" : "var(--err)";
   }
   function glitch() {
-    // Для светлых тем аберрация и резкое затемнение SVG выглядят как артефакт,
-    // а не как телеметрия. Кольца и живые показатели при этом остаются.
     if (["shiro", "sakura"].includes(document.documentElement.dataset.theme)) return;
     if (Math.random() > 0.6) return;
     const g = els.ca; if (!g) return;
     g.setAttribute("transform", "translate(3,-1) skewX(-3)");
     svg.style.opacity = "0.55";
-    setTimeout(() => g && g.setAttribute("transform", "translate(-2,1)"), 65);
-    setTimeout(() => { if (g) g.setAttribute("transform", ""); svg.style.opacity = ""; }, 150);
+    later(() => g?.setAttribute("transform", "translate(-2,1)"), 65);
+    later(() => { if (g) g.setAttribute("transform", ""); svg.style.opacity = ""; }, 150);
   }
 
   function sync() {
@@ -153,22 +160,49 @@ export function initHeroHud(svg, { getState, getTarget } = {}) {
     cycleErr();
   }
 
-  // Вращение колец (outer/seg/ticks) теперь живёт в CSS на компоновщике
-  // (см. .hud__outer/seg/ticks + @keyframes hud-spin в app.css) — без покадровой
-  // перерисовки SVG. Здесь остаются только редкие точечные обновления
-  // (часы/INTEGRITY/ERR/глитч) на setInterval. HUD анимируется ВСЕГДА.
-  updClock(); sync();
-  timers.push(setInterval(updClock, 1000));
-  timers.push(setInterval(updIntegrity, 1600));
-  timers.push(setInterval(blink, 1500));
-  timers.push(setInterval(cycleErr, 2400));
-  timers.push(setInterval(glitch, 4000));
+  function setCssAnimationState(value) {
+    for (const key of ["outer", "seg", "ticks"]) {
+      if (els[key]) els[key].style.animationPlayState = value;
+    }
+  }
+
+  function stopTimers() {
+    if (!running) return;
+    running = false;
+    timers.forEach(clearInterval);
+    timers = [];
+    transientTimers.forEach(clearTimeout);
+    transientTimers = [];
+    setCssAnimationState("paused");
+    perfObserver.increment("hud.pauses");
+  }
+
+  function startTimers() {
+    if (running) return;
+    running = true;
+    setCssAnimationState("running");
+    updClock();
+    sync();
+    timers.push(setInterval(updClock, 1000));
+    timers.push(setInterval(updIntegrity, 1600));
+    timers.push(setInterval(blink, 1500));
+    timers.push(setInterval(cycleErr, 2400));
+    timers.push(setInterval(glitch, 4000));
+    perfObserver.increment("hud.resumes");
+  }
+
+  const unsubscribe = activity?.subscribe?.((snapshot) => {
+    if (snapshot.visible) startTimers();
+    else stopTimers();
+  }) || (() => {});
+
+  if (!activity?.subscribe) startTimers();
 
   return {
     sync,
     destroy() {
-      timers.forEach(clearInterval);
-      timers = [];
+      unsubscribe();
+      stopTimers();
     },
   };
 }

--- a/src/lib/performance-observer.js
+++ b/src/lib/performance-observer.js
@@ -1,0 +1,127 @@
+// Ninety · lightweight performance observability.
+//
+// The collector is intentionally dependency-free and safe for production builds:
+// callers opt in explicitly, samples are bounded, and snapshots contain only
+// timings/counters (never profile URLs, node credentials or destinations).
+
+const DEFAULT_SAMPLE_CAP = 120;
+
+function finiteNumber(value, fallback = 0) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function nowMs(clock) {
+  try { return finiteNumber(clock?.(), Date.now()); }
+  catch { return Date.now(); }
+}
+
+export function createPerformanceObserver({
+  enabled = true,
+  sampleCap = DEFAULT_SAMPLE_CAP,
+  clock = () => globalThis.performance?.now?.() ?? Date.now(),
+  wallClock = () => Date.now(),
+} = {}) {
+  const cap = Math.max(1, Math.min(1000, Math.trunc(finiteNumber(sampleCap, DEFAULT_SAMPLE_CAP))));
+  const counters = new Map();
+  const gauges = new Map();
+  const samples = new Map();
+  const marks = new Map();
+  const startedAt = nowMs(wallClock);
+
+  function active() { return enabled === true; }
+
+  function increment(name, amount = 1) {
+    if (!active() || !name) return 0;
+    const next = finiteNumber(counters.get(name)) + finiteNumber(amount, 1);
+    counters.set(String(name), next);
+    return next;
+  }
+
+  function gauge(name, value) {
+    if (!active() || !name) return 0;
+    const next = finiteNumber(value);
+    gauges.set(String(name), next);
+    return next;
+  }
+
+  function sample(name, value, meta = null) {
+    if (!active() || !name) return null;
+    const entry = {
+      at: nowMs(wallClock),
+      value: finiteNumber(value),
+      ...(meta && typeof meta === "object" ? { meta: { ...meta } } : {}),
+    };
+    const key = String(name);
+    const list = samples.get(key) || [];
+    list.push(entry);
+    if (list.length > cap) list.splice(0, list.length - cap);
+    samples.set(key, list);
+    return entry;
+  }
+
+  function mark(name) {
+    if (!active() || !name) return null;
+    const value = nowMs(clock);
+    marks.set(String(name), value);
+    return value;
+  }
+
+  function measure(name, startName, endName = null, meta = null) {
+    if (!active() || !name || !startName) return null;
+    const start = marks.get(String(startName));
+    if (!Number.isFinite(start)) return null;
+    const end = endName == null ? nowMs(clock) : marks.get(String(endName));
+    if (!Number.isFinite(end)) return null;
+    return sample(String(name), Math.max(0, end - start), meta);
+  }
+
+  function time(name, meta = null) {
+    if (!active() || !name) return () => null;
+    const started = nowMs(clock);
+    let finished = false;
+    return (extraMeta = null) => {
+      if (finished) return null;
+      finished = true;
+      const mergedMeta = meta || extraMeta
+        ? { ...(meta || {}), ...(extraMeta || {}) }
+        : null;
+      return sample(String(name), Math.max(0, nowMs(clock) - started), mergedMeta);
+    };
+  }
+
+  function reset() {
+    counters.clear();
+    gauges.clear();
+    samples.clear();
+    marks.clear();
+  }
+
+  function snapshot() {
+    const sampleSnapshot = {};
+    for (const [name, list] of samples) sampleSnapshot[name] = list.map((entry) => ({ ...entry }));
+    return {
+      schemaVersion: 1,
+      createdAt: nowMs(wallClock),
+      startedAt,
+      counters: Object.fromEntries(counters),
+      gauges: Object.fromEntries(gauges),
+      samples: sampleSnapshot,
+    };
+  }
+
+  return {
+    increment,
+    gauge,
+    sample,
+    mark,
+    measure,
+    time,
+    reset,
+    snapshot,
+  };
+}
+
+// Shared collector for modules that do not need dependency injection. Tests and
+// sensitive workflows can create isolated collectors via createPerformanceObserver.
+export const perfObserver = createPerformanceObserver();

--- a/tests/activity-controller.test.mjs
+++ b/tests/activity-controller.test.mjs
@@ -1,0 +1,67 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createActivityController } from "../src/lib/activity-controller.js";
+
+function eventTarget(extra = {}) {
+  const listeners = new Map();
+  return {
+    ...extra,
+    addEventListener(name, fn) {
+      const set = listeners.get(name) || new Set();
+      set.add(fn);
+      listeners.set(name, set);
+    },
+    removeEventListener(name, fn) { listeners.get(name)?.delete(fn); },
+    emit(name) { for (const fn of [...(listeners.get(name) || [])]) fn(); },
+    count(name) { return listeners.get(name)?.size || 0; },
+  };
+}
+
+test("controller follows visibility, focus and active view", () => {
+  const doc = eventTarget({ visibilityState: "visible", hasFocus: () => true });
+  const win = eventTarget();
+  const controller = createActivityController({ document: doc, window: win });
+  const states = [];
+  controller.subscribe((state) => states.push({ ...state }));
+  controller.mount();
+
+  assert.equal(controller.isInteractive("home"), true);
+  controller.setView("logs");
+  assert.equal(controller.isInteractive("home"), false);
+  assert.equal(controller.isInteractive("logs"), true);
+
+  doc.visibilityState = "hidden";
+  doc.emit("visibilitychange");
+  assert.equal(controller.isVisible(), false);
+  assert.equal(controller.isInteractive("logs"), false);
+
+  doc.visibilityState = "visible";
+  doc.emit("visibilitychange");
+  win.emit("blur");
+  assert.equal(controller.isFocused(), false);
+  win.emit("focus");
+  assert.equal(controller.isInteractive("logs"), true);
+  assert.ok(states.length >= 5);
+
+  controller.destroy();
+  assert.equal(doc.count("visibilitychange"), 0);
+  assert.equal(win.count("focus"), 0);
+  assert.equal(win.count("blur"), 0);
+});
+
+test("mount and no-op state updates are idempotent", () => {
+  const doc = eventTarget({ visibilityState: "visible", hasFocus: () => true });
+  const win = eventTarget();
+  const controller = createActivityController({ document: doc, window: win });
+  let notifications = 0;
+  controller.subscribe(() => notifications++);
+  controller.mount();
+  controller.mount();
+  controller.setView("home");
+  doc.emit("visibilitychange");
+
+  assert.equal(doc.count("visibilitychange"), 1);
+  assert.equal(win.count("focus"), 1);
+  assert.equal(notifications, 2); // immediate subscribe + initial mount snapshot
+});

--- a/tests/performance-observer.test.mjs
+++ b/tests/performance-observer.test.mjs
@@ -1,0 +1,63 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createPerformanceObserver } from "../src/lib/performance-observer.js";
+
+test("collector tracks counters, gauges and bounded samples", () => {
+  let wall = 1000;
+  const observer = createPerformanceObserver({
+    sampleCap: 2,
+    clock: () => 50,
+    wallClock: () => wall++,
+  });
+
+  assert.equal(observer.increment("ipc.calls"), 1);
+  assert.equal(observer.increment("ipc.calls", 2), 3);
+  assert.equal(observer.gauge("window.visible", true), 1);
+  observer.sample("render.ms", 1);
+  observer.sample("render.ms", 2);
+  observer.sample("render.ms", 3, { view: "home" });
+
+  const snapshot = observer.snapshot();
+  assert.equal(snapshot.schemaVersion, 1);
+  assert.equal(snapshot.counters["ipc.calls"], 3);
+  assert.equal(snapshot.gauges["window.visible"], 1);
+  assert.deepEqual(snapshot.samples["render.ms"].map((x) => x.value), [2, 3]);
+  assert.deepEqual(snapshot.samples["render.ms"][1].meta, { view: "home" });
+});
+
+test("marks and one-shot timers record durations", () => {
+  let monotonic = 10;
+  const observer = createPerformanceObserver({
+    clock: () => monotonic,
+    wallClock: () => 500,
+  });
+
+  observer.mark("startup.begin");
+  monotonic = 25;
+  observer.mark("startup.ready");
+  observer.measure("startup.ms", "startup.begin", "startup.ready");
+
+  monotonic = 40;
+  const finish = observer.time("ipc.ms", { command: "health_snapshot" });
+  monotonic = 46;
+  finish();
+  monotonic = 99;
+  assert.equal(finish(), null);
+
+  const snapshot = observer.snapshot();
+  assert.equal(snapshot.samples["startup.ms"][0].value, 15);
+  assert.equal(snapshot.samples["ipc.ms"][0].value, 6);
+  assert.deepEqual(snapshot.samples["ipc.ms"][0].meta, { command: "health_snapshot" });
+});
+
+test("disabled collector is a no-op", () => {
+  const observer = createPerformanceObserver({ enabled: false });
+  observer.increment("x");
+  observer.gauge("y", 1);
+  observer.sample("z", 1);
+  observer.mark("a");
+  assert.deepEqual(observer.snapshot().counters, {});
+  assert.deepEqual(observer.snapshot().gauges, {});
+  assert.deepEqual(observer.snapshot().samples, {});
+});


### PR DESCRIPTION
## Что сделано
- добавлен единый `activity-controller` для visibility/focus/view state;
- HUD теперь полностью останавливает JS-таймеры и CSS animation play state, когда WebView скрыт;
- transient timeout'ы очищаются при pause/destroy;
- добавлены performance counters и unit-тесты переходов.

## Эффект
Скрытое в трее окно больше не просыпается ради часов, blink, integrity, error-cycle и glitch HUD.

## Проверка
- `npm test`
- `npm run lint`

Стек PR: 2/7. Base: PR #66.