### PR TITLE
perf: deduplicate Clash telemetry polling

### DIFF
--- a/src/lib/activity-controller.js
+++ b/src/lib/activity-controller.js
@@ -1,0 +1,97 @@
+// Ninety · foreground/background activity controller.
+//
+// Visual modules subscribe to this store instead of running independent work
+// while WebView2 is hidden in the tray. Network safety watchdogs remain outside
+// this controller and continue to run regardless of window visibility.
+
+import { perfObserver } from "/lib/performance-observer.js";
+
+function readVisible(doc) {
+  return !doc || doc.visibilityState !== "hidden";
+}
+
+export function createActivityController({
+  document: doc = globalThis.document,
+  window: win = globalThis.window,
+  initialView = "home",
+} = {}) {
+  let state = Object.freeze({
+    visible: readVisible(doc),
+    focused: typeof doc?.hasFocus === "function" ? !!doc.hasFocus() : true,
+    view: initialView,
+  });
+  const listeners = new Set();
+  let mounted = false;
+
+  function notify(previous) {
+    perfObserver.gauge("activity.visible", state.visible ? 1 : 0);
+    perfObserver.gauge("activity.focused", state.focused ? 1 : 0);
+    for (const listener of [...listeners]) {
+      try { listener(state, previous); } catch (error) {
+        console.warn("activity listener failed", error);
+      }
+    }
+  }
+
+  function patch(next) {
+    const candidate = { ...state, ...next };
+    if (candidate.visible === state.visible
+      && candidate.focused === state.focused
+      && candidate.view === state.view) return state;
+    const previous = state;
+    state = Object.freeze(candidate);
+    notify(previous);
+    return state;
+  }
+
+  const onVisibility = () => patch({ visible: readVisible(doc) });
+  const onFocus = () => patch({ focused: true });
+  const onBlur = () => patch({ focused: false });
+
+  function mount() {
+    if (mounted) return;
+    mounted = true;
+    doc?.addEventListener?.("visibilitychange", onVisibility);
+    win?.addEventListener?.("focus", onFocus);
+    win?.addEventListener?.("blur", onBlur);
+    notify(state);
+  }
+
+  function destroy() {
+    if (!mounted) return;
+    mounted = false;
+    doc?.removeEventListener?.("visibilitychange", onVisibility);
+    win?.removeEventListener?.("focus", onFocus);
+    win?.removeEventListener?.("blur", onBlur);
+    listeners.clear();
+  }
+
+  function subscribe(listener, { immediate = true } = {}) {
+    if (typeof listener !== "function") return () => {};
+    listeners.add(listener);
+    if (immediate) listener(state, state);
+    return () => listeners.delete(listener);
+  }
+
+  function setView(view) {
+    if (typeof view === "string" && view) patch({ view });
+  }
+
+  function isInteractive(view = null) {
+    return state.visible && state.focused && (!view || state.view === view);
+  }
+
+  return {
+    mount,
+    destroy,
+    subscribe,
+    setView,
+    snapshot: () => state,
+    isVisible: () => state.visible,
+    isFocused: () => state.focused,
+    isInteractive,
+  };
+}
+
+export const activityController = createActivityController();
+activityController.mount();

--- a/src/lib/clash-api.js
+++ b/src/lib/clash-api.js
@@ -1,14 +1,21 @@
 // Тонкий JS-wrapper над Tauri-командами clash-API.
 
+import { perfObserver } from "/lib/performance-observer.js";
+import { createTelemetryCache } from "/lib/telemetry-cache.js";
+
 const invoke = window.__TAURI__?.core?.invoke
   ?? (() => Promise.reject(new Error("Tauri invoke недоступен")));
 
 const DEFAULT_PORT = 9090;
 const DEFAULT_URL = "https://www.gstatic.com/generate_204";
+const PROXIES_TTL_MS = 1200;
+const CONNECTIONS_TTL_MS = 800;
+const TRAFFIC_TTL_MS = 800;
 
 let runtimeProvider = null;
 let selectionRevision = 0;
 let selectionQueue = Promise.resolve();
+const telemetryCache = createTelemetryCache();
 
 export class ClashApiError extends Error {
   constructor(operation, message, { port, processGeneration } = {}) {
@@ -23,6 +30,7 @@ export class ClashApiError extends Error {
 
 export function configureClashRuntime(provider) {
   runtimeProvider = provider || null;
+  telemetryCache.clear();
 }
 
 function captureRuntime(explicitToken) {
@@ -37,9 +45,20 @@ function assertRuntime(token, operation) {
   if (token && runtimeProvider?.assertCurrent) runtimeProvider.assertCurrent(token, operation);
 }
 
+function telemetryKey(operation, port, token) {
+  return `${operation}:${port}:${token?.processGeneration ?? "none"}`;
+}
+
+export function invalidateClashTelemetry(scope = null) {
+  if (!scope) telemetryCache.invalidate();
+  else telemetryCache.invalidate(`${scope}:`);
+}
+
 async function call(operation, command, args, { token } = {}) {
   const captured = captureRuntime(token);
   const port = runtimePort(args.port, captured);
+  const finish = perfObserver.time("clash.ipc.ms", { operation, port });
+  perfObserver.increment("clash.ipc.calls");
   try {
     assertRuntime(captured, operation);
     const value = await invoke(command, { ...args, port });
@@ -51,13 +70,29 @@ async function call(operation, command, args, { token } = {}) {
       port,
       processGeneration: captured?.processGeneration,
     });
+  } finally {
+    finish();
   }
 }
 
+async function cachedCall(operation, command, args, options, ttlMs) {
+  const captured = captureRuntime(options?.token);
+  const port = runtimePort(args.port, captured);
+  const key = telemetryKey(operation, port, captured);
+  const cached = telemetryCache.peek(key);
+  if (!options?.fresh && cached !== undefined) perfObserver.increment(`clash.cache.peek.${operation}`);
+  return telemetryCache.get(
+    key,
+    () => call(operation, command, { ...args, port }, { token: captured }),
+    { ttlMs, force: options?.fresh === true },
+  );
+}
+
 export async function getProxies(port, options = {}) {
-  const value = await call("getProxies", "clash_get_proxies", { port }, options);
+  const value = await cachedCall("proxies", "clash_get_proxies", { port }, options, PROXIES_TTL_MS);
   if (!value || typeof value !== "object" || !value.proxies || typeof value.proxies !== "object") {
     const token = captureRuntime(options.token);
+    invalidateClashTelemetry("proxies");
     throw new ClashApiError("getProxies", "невалидная структура ответа", {
       port: runtimePort(port, token), processGeneration: token?.processGeneration,
     });
@@ -67,16 +102,43 @@ export async function getProxies(port, options = {}) {
 
 // Живые соединения для монитора правил маршрутизации:
 // [{ process, processPath, host, destinationIP, outbound:"direct"|"proxy"|"block" }].
-// Процесс резолвится у каждого соединения (в конфиге есть форсирующее
-// process-правило → sing-box ищет владельца сокета на каждом коннекте). Форк шлёт
-// только processPath; имя (process) Rust выводит как basename пути. process=null
-// лишь для соединений, у которых ОС не отдала владельца сокета (системные и т.п.).
+// Все одновременные consumers делят один IPC/HTTP snapshot в пределах TTL.
 export async function getConnections(port, options = {}) {
-  const value = await call("getConnections", "clash_get_connections", { port }, options);
-  if (!Array.isArray(value)) throw new ClashApiError("getConnections", "ожидался массив", {
-    port: runtimePort(port, captureRuntime(options.token)),
-  });
+  const value = await cachedCall(
+    "connections",
+    "clash_get_connections",
+    { port },
+    options,
+    CONNECTIONS_TTL_MS,
+  );
+  if (!Array.isArray(value)) {
+    invalidateClashTelemetry("connections");
+    throw new ClashApiError("getConnections", "ожидался массив", {
+      port: runtimePort(port, captureRuntime(options.token)),
+    });
+  }
   return value;
+}
+
+// Кумулятивные totals ядра. traffic-meter использует тот же single-flight слой,
+// поэтому параллельный тик не создаёт второй /connections request.
+export async function getTrafficTotal(port, options = {}) {
+  const value = await cachedCall(
+    "traffic",
+    "clash_traffic_total",
+    { port },
+    options,
+    TRAFFIC_TTL_MS,
+  );
+  const up = Number(value?.up);
+  const down = Number(value?.down);
+  if (!Number.isFinite(up) || !Number.isFinite(down)) {
+    invalidateClashTelemetry("traffic");
+    throw new ClashApiError("getTrafficTotal", "ожидались числовые up/down", {
+      port: runtimePort(port, captureRuntime(options.token)),
+    });
+  }
+  return { up, down };
 }
 
 // Процессы с исходящей сетевой активностью (для выбора при создании правила):
@@ -86,11 +148,15 @@ export async function listNetworkProcesses() {
 }
 
 export async function testNode(name, { port, url = DEFAULT_URL, timeoutMs = 5000, token } = {}) {
-  return call("testNode", "clash_test_node", { port, name, url, timeoutMs }, { token });
+  const value = await call("testNode", "clash_test_node", { port, name, url, timeoutMs }, { token });
+  invalidateClashTelemetry("proxies");
+  return value;
 }
 
 export async function testGroup(group, { port, url = DEFAULT_URL, timeoutMs = 5000, token } = {}) {
-  return call("testGroup", "clash_test_group", { port, group, url, timeoutMs }, { token });
+  const value = await call("testGroup", "clash_test_group", { port, group, url, timeoutMs }, { token });
+  invalidateClashTelemetry("proxies");
+  return value;
 }
 
 // Замер задержки эффективной ноды для hero/location-card.
@@ -98,12 +164,7 @@ export async function testGroup(group, { port, url = DEFAULT_URL, timeoutMs = 50
 // Корень бага «в списке 30мс, на главной 100+»: апстрим-форк в обработчике
 // одиночного GET /proxies/{name}/delay меряет через context.Background(), который
 // НЕ несёт box-ctx → IsUnifiedDelayFromContext=false → один HEAD с полным dial+TLS
-// (завышение ~3x). Групповой /group/{name}/delay меряет через r.Context() → unified
-// (чистый второй RTT) → 30мс. min-из-N не спасал: каждый /delay — холодный.
-// Перейти на групповой нельзя — он interval-gated (молчит 600с, не перемеряет) →
-// заморозка. Поэтому в CI одиночный обработчик пропатчен на r.Context() (build.yml):
-// теперь /proxies/{name}/delay тоже unified И перемеряет каждый вызов (без gate) →
-// число совпадает со списком, автозамер и клик живые. Это и есть единый путь здесь.
+// (завышение ~3x). В CI одиночный handler патчится на unified context.
 export async function refreshEffectiveDelay({ port, url = DEFAULT_URL, timeoutMs = 5000, token } = {}) {
   let data;
   try { data = await getProxies(port, { token }); } catch (e) {
@@ -126,8 +187,9 @@ export function selectProxy(group, name, { port, token } = {}) {
     if (revision !== selectionRevision) return { stale: true };
     const captured = captureRuntime(token);
     await call("selectProxy", "clash_select_proxy", { port, group, name }, { token: captured });
+    invalidateClashTelemetry("proxies");
     if (revision !== selectionRevision) return { stale: true };
-    const confirmed = await getProxies(port, { token: captured });
+    const confirmed = await getProxies(port, { token: captured, fresh: true });
     if (revision !== selectionRevision) return { stale: true };
     const actual = confirmed?.proxies?.[group]?.now;
     if (actual !== name) {
@@ -161,7 +223,6 @@ export function pickEffectiveNode(proxiesResp) {
   const sel = proxies.proxy;
   if (!sel) return null;
   if (!sel.now) {
-    // single-mode: "proxy" — это и есть конечный outbound, а не Selector
     return sel.type && sel.type.toLowerCase() === "selector" ? null : "proxy";
   }
   if (sel.now === "auto") {
@@ -170,12 +231,10 @@ export function pickEffectiveNode(proxiesResp) {
   return sel.now;
 }
 
-// Совместимая точка для старого кода — теперь == pickSelectorNow.
 export function pickActiveNode(proxiesResp) {
   return pickSelectorNow(proxiesResp);
 }
 
-// Последний delay по истории
 export function lastDelay(proxyObj) {
   if (!proxyObj) return 0;
   const hist = proxyObj.history;
@@ -186,8 +245,6 @@ export function lastDelay(proxyObj) {
   return 0;
 }
 
-// Hiddify-UX: 0 или >65000 трактуем как "не дотянулись" — "Connecting"/dead.
-// Прочее — числовая градация.
 export function gradeDelay(ms) {
   if (!ms || ms <= 0) return "dead";
   if (ms >= 65000) return "dead";

--- a/src/lib/hero-hud.js
+++ b/src/lib/hero-hud.js
@@ -7,13 +7,13 @@
 //      clock y=60→106, INTEGRITY y=330→298, ERR y=350→372.  (раньше всё было свалено
 //      в один 20px-пятак внизу + часы лезли на дугу SYSTEM STATUS).
 //   2) Анимация HUD больше НЕ глушится prefers-reduced-motion: вращение колец, глитч,
-//      INTEGRITY/ERR/blink работают всегда. HUD — смысловой центр экрана, а не декор;
-//      при выключенных в Windows анимациях он раньше полностью замерзал (играла только
-//      видео-маска). Если нужна строгая a11y — погасите .hud__outer/seg/ticks в app.css.
+//      INTEGRITY/ERR/blink работают всегда, пока окно действительно видно. В трее
+//      визуальная телеметрия полностью ставится на паузу через activity-controller.
 //   3) Вращение колец перенесено с rAF+setAttribute('transform') на CSS-анимацию,
 //      идущую на компоновщике (GPU): слой растрится один раз, дальше только крутится.
-//      Это убирает покадровую перерисовку всего SVG (была причина высокой нагрузки на
-//      GPU-процесс WebView2 на главном экране). Скорости/направления не изменились.
+
+import { activityController } from "/lib/activity-controller.js";
+import { perfObserver } from "/lib/performance-observer.js";
 
 const CX = 200, CY = 200;
 const P = (deg, r) => [CX + Math.cos((deg * Math.PI) / 180) * r, CY + Math.sin((deg * Math.PI) / 180) * r];
@@ -96,14 +96,23 @@ const ERR_OFFLINE = ["NO LINK", "SEARCHING…", "ERR_ON_KNW"];
 const pad = (n) => String(n).padStart(2, "0");
 
 // getState() → 'secured' | 'linking' | 'standby'.  getTarget() → строка-тег сервера или null.
-export function initHeroHud(svg, { getState, getTarget } = {}) {
+export function initHeroHud(svg, { getState, getTarget, activity = activityController } = {}) {
   if (!svg) return { destroy() {} };
   svg.innerHTML = buildHud();
   const els = {};
   svg.querySelectorAll("[data-hud]").forEach((el) => { els[el.dataset.hud] = el; });
 
   const st = () => (getState?.() || "standby");
-  let timers = [], intgVal = 0, ei = 0, clockStr = "";
+  let timers = [], transientTimers = [], intgVal = 0, ei = 0, clockStr = "";
+  let running = false;
+
+  function later(fn, ms) {
+    const id = setTimeout(() => {
+      transientTimers = transientTimers.filter((value) => value !== id);
+      if (running) fn();
+    }, ms);
+    transientTimers.push(id);
+  }
 
   function updClock() {
     const d = new Date();
@@ -121,7 +130,7 @@ export function initHeroHud(svg, { getState, getTarget } = {}) {
   function blink() {
     if (!els.sys) return;
     els.sys.setAttribute("opacity", "0.18");
-    setTimeout(() => els.sys && els.sys.setAttribute("opacity", "1"), 105);
+    later(() => els.sys?.setAttribute("opacity", "1"), 105);
   }
   function cycleErr() {
     if (!els.err) return;
@@ -132,15 +141,13 @@ export function initHeroHud(svg, { getState, getTarget } = {}) {
     els.err.style.fill = sec ? "var(--text-lo)" : "var(--err)";
   }
   function glitch() {
-    // Для светлых тем аберрация и резкое затемнение SVG выглядят как артефакт,
-    // а не как телеметрия. Кольца и живые показатели при этом остаются.
     if (["shiro", "sakura"].includes(document.documentElement.dataset.theme)) return;
     if (Math.random() > 0.6) return;
     const g = els.ca; if (!g) return;
     g.setAttribute("transform", "translate(3,-1) skewX(-3)");
     svg.style.opacity = "0.55";
-    setTimeout(() => g && g.setAttribute("transform", "translate(-2,1)"), 65);
-    setTimeout(() => { if (g) g.setAttribute("transform", ""); svg.style.opacity = ""; }, 150);
+    later(() => g?.setAttribute("transform", "translate(-2,1)"), 65);
+    later(() => { if (g) g.setAttribute("transform", ""); svg.style.opacity = ""; }, 150);
   }
 
   function sync() {
@@ -153,22 +160,49 @@ export function initHeroHud(svg, { getState, getTarget } = {}) {
     cycleErr();
   }
 
-  // Вращение колец (outer/seg/ticks) теперь живёт в CSS на компоновщике
-  // (см. .hud__outer/seg/ticks + @keyframes hud-spin в app.css) — без покадровой
-  // перерисовки SVG. Здесь остаются только редкие точечные обновления
-  // (часы/INTEGRITY/ERR/глитч) на setInterval. HUD анимируется ВСЕГДА.
-  updClock(); sync();
-  timers.push(setInterval(updClock, 1000));
-  timers.push(setInterval(updIntegrity, 1600));
-  timers.push(setInterval(blink, 1500));
-  timers.push(setInterval(cycleErr, 2400));
-  timers.push(setInterval(glitch, 4000));
+  function setCssAnimationState(value) {
+    for (const key of ["outer", "seg", "ticks"]) {
+      if (els[key]) els[key].style.animationPlayState = value;
+    }
+  }
+
+  function stopTimers() {
+    if (!running) return;
+    running = false;
+    timers.forEach(clearInterval);
+    timers = [];
+    transientTimers.forEach(clearTimeout);
+    transientTimers = [];
+    setCssAnimationState("paused");
+    perfObserver.increment("hud.pauses");
+  }
+
+  function startTimers() {
+    if (running) return;
+    running = true;
+    setCssAnimationState("running");
+    updClock();
+    sync();
+    timers.push(setInterval(updClock, 1000));
+    timers.push(setInterval(updIntegrity, 1600));
+    timers.push(setInterval(blink, 1500));
+    timers.push(setInterval(cycleErr, 2400));
+    timers.push(setInterval(glitch, 4000));
+    perfObserver.increment("hud.resumes");
+  }
+
+  const unsubscribe = activity?.subscribe?.((snapshot) => {
+    if (snapshot.visible) startTimers();
+    else stopTimers();
+  }) || (() => {});
+
+  if (!activity?.subscribe) startTimers();
 
   return {
     sync,
     destroy() {
-      timers.forEach(clearInterval);
-      timers = [];
+      unsubscribe();
+      stopTimers();
     },
   };
 }

--- a/src/lib/performance-observer.js
+++ b/src/lib/performance-observer.js
@@ -1,0 +1,127 @@
+// Ninety · lightweight performance observability.
+//
+// The collector is intentionally dependency-free and safe for production builds:
+// callers opt in explicitly, samples are bounded, and snapshots contain only
+// timings/counters (never profile URLs, node credentials or destinations).
+
+const DEFAULT_SAMPLE_CAP = 120;
+
+function finiteNumber(value, fallback = 0) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function nowMs(clock) {
+  try { return finiteNumber(clock?.(), Date.now()); }
+  catch { return Date.now(); }
+}
+
+export function createPerformanceObserver({
+  enabled = true,
+  sampleCap = DEFAULT_SAMPLE_CAP,
+  clock = () => globalThis.performance?.now?.() ?? Date.now(),
+  wallClock = () => Date.now(),
+} = {}) {
+  const cap = Math.max(1, Math.min(1000, Math.trunc(finiteNumber(sampleCap, DEFAULT_SAMPLE_CAP))));
+  const counters = new Map();
+  const gauges = new Map();
+  const samples = new Map();
+  const marks = new Map();
+  const startedAt = nowMs(wallClock);
+
+  function active() { return enabled === true; }
+
+  function increment(name, amount = 1) {
+    if (!active() || !name) return 0;
+    const next = finiteNumber(counters.get(name)) + finiteNumber(amount, 1);
+    counters.set(String(name), next);
+    return next;
+  }
+
+  function gauge(name, value) {
+    if (!active() || !name) return 0;
+    const next = finiteNumber(value);
+    gauges.set(String(name), next);
+    return next;
+  }
+
+  function sample(name, value, meta = null) {
+    if (!active() || !name) return null;
+    const entry = {
+      at: nowMs(wallClock),
+      value: finiteNumber(value),
+      ...(meta && typeof meta === "object" ? { meta: { ...meta } } : {}),
+    };
+    const key = String(name);
+    const list = samples.get(key) || [];
+    list.push(entry);
+    if (list.length > cap) list.splice(0, list.length - cap);
+    samples.set(key, list);
+    return entry;
+  }
+
+  function mark(name) {
+    if (!active() || !name) return null;
+    const value = nowMs(clock);
+    marks.set(String(name), value);
+    return value;
+  }
+
+  function measure(name, startName, endName = null, meta = null) {
+    if (!active() || !name || !startName) return null;
+    const start = marks.get(String(startName));
+    if (!Number.isFinite(start)) return null;
+    const end = endName == null ? nowMs(clock) : marks.get(String(endName));
+    if (!Number.isFinite(end)) return null;
+    return sample(String(name), Math.max(0, end - start), meta);
+  }
+
+  function time(name, meta = null) {
+    if (!active() || !name) return () => null;
+    const started = nowMs(clock);
+    let finished = false;
+    return (extraMeta = null) => {
+      if (finished) return null;
+      finished = true;
+      const mergedMeta = meta || extraMeta
+        ? { ...(meta || {}), ...(extraMeta || {}) }
+        : null;
+      return sample(String(name), Math.max(0, nowMs(clock) - started), mergedMeta);
+    };
+  }
+
+  function reset() {
+    counters.clear();
+    gauges.clear();
+    samples.clear();
+    marks.clear();
+  }
+
+  function snapshot() {
+    const sampleSnapshot = {};
+    for (const [name, list] of samples) sampleSnapshot[name] = list.map((entry) => ({ ...entry }));
+    return {
+      schemaVersion: 1,
+      createdAt: nowMs(wallClock),
+      startedAt,
+      counters: Object.fromEntries(counters),
+      gauges: Object.fromEntries(gauges),
+      samples: sampleSnapshot,
+    };
+  }
+
+  return {
+    increment,
+    gauge,
+    sample,
+    mark,
+    measure,
+    time,
+    reset,
+    snapshot,
+  };
+}
+
+// Shared collector for modules that do not need dependency injection. Tests and
+// sensitive workflows can create isolated collectors via createPerformanceObserver.
+export const perfObserver = createPerformanceObserver();

--- a/src/lib/telemetry-cache.js
+++ b/src/lib/telemetry-cache.js
@@ -1,0 +1,57 @@
+// Small TTL + single-flight cache used by Clash telemetry readers.
+// Values are kept in-memory only and invalidated on runtime generation changes.
+
+export function createTelemetryCache({ clock = () => Date.now() } = {}) {
+  const values = new Map();
+  const inFlight = new Map();
+
+  function now() {
+    const value = Number(clock());
+    return Number.isFinite(value) ? value : Date.now();
+  }
+
+  async function get(key, loader, { ttlMs = 0, force = false } = {}) {
+    const normalizedKey = String(key);
+    const ttl = Math.max(0, Number(ttlMs) || 0);
+    const current = values.get(normalizedKey);
+    const at = now();
+    if (!force && current && at - current.at <= ttl) return current.value;
+
+    const pending = inFlight.get(normalizedKey);
+    if (pending) return pending;
+
+    const task = Promise.resolve()
+      .then(loader)
+      .then((value) => {
+        values.set(normalizedKey, { at: now(), value });
+        return value;
+      })
+      .finally(() => {
+        if (inFlight.get(normalizedKey) === task) inFlight.delete(normalizedKey);
+      });
+    inFlight.set(normalizedKey, task);
+    return task;
+  }
+
+  function invalidate(prefix = null) {
+    if (prefix == null) {
+      values.clear();
+      return;
+    }
+    const normalized = String(prefix);
+    for (const key of values.keys()) {
+      if (key.startsWith(normalized)) values.delete(key);
+    }
+  }
+
+  function peek(key) {
+    return values.get(String(key))?.value;
+  }
+
+  function clear() {
+    values.clear();
+    inFlight.clear();
+  }
+
+  return { get, invalidate, peek, clear };
+}

--- a/src/lib/traffic-meter.js
+++ b/src/lib/traffic-meter.js
@@ -9,8 +9,9 @@
 // по каждому источнику — «использовано за N дней» переживает реконнекты и
 // перезапуски приложения.
 
+import { getTrafficTotal } from "/lib/clash-api.js";
+
 const KEY_PREFIX = "ninety.traffic.";
-const invoke = window.__TAURI__?.core?.invoke;
 
 function load(sourceKey) {
   try {
@@ -61,10 +62,10 @@ async function poll() {
   const runId = meterRunId;
   const key = curKey;
   const token = runtimeToken;
-  if (!invoke || !key) return;
+  if (!key) return;
   if (token && runtimeProvider?.isCurrent && !runtimeProvider.isCurrent(token)) return;
   let t;
-  try { t = await invoke("clash_traffic_total", { port: clashPort }); }
+  try { t = await getTrafficTotal(clashPort, { token }); }
   catch { return; } // ядро ещё не подняло clash-API / уже умерло — пропускаем тик
   if (runId !== meterRunId || key !== curKey || token !== runtimeToken) return;
   if (token && runtimeProvider?.isCurrent && !runtimeProvider.isCurrent(token)) return;

--- a/tests/activity-controller.test.mjs
+++ b/tests/activity-controller.test.mjs
@@ -1,0 +1,67 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createActivityController } from "../src/lib/activity-controller.js";
+
+function eventTarget(extra = {}) {
+  const listeners = new Map();
+  return {
+    ...extra,
+    addEventListener(name, fn) {
+      const set = listeners.get(name) || new Set();
+      set.add(fn);
+      listeners.set(name, set);
+    },
+    removeEventListener(name, fn) { listeners.get(name)?.delete(fn); },
+    emit(name) { for (const fn of [...(listeners.get(name) || [])]) fn(); },
+    count(name) { return listeners.get(name)?.size || 0; },
+  };
+}
+
+test("controller follows visibility, focus and active view", () => {
+  const doc = eventTarget({ visibilityState: "visible", hasFocus: () => true });
+  const win = eventTarget();
+  const controller = createActivityController({ document: doc, window: win });
+  const states = [];
+  controller.subscribe((state) => states.push({ ...state }));
+  controller.mount();
+
+  assert.equal(controller.isInteractive("home"), true);
+  controller.setView("logs");
+  assert.equal(controller.isInteractive("home"), false);
+  assert.equal(controller.isInteractive("logs"), true);
+
+  doc.visibilityState = "hidden";
+  doc.emit("visibilitychange");
+  assert.equal(controller.isVisible(), false);
+  assert.equal(controller.isInteractive("logs"), false);
+
+  doc.visibilityState = "visible";
+  doc.emit("visibilitychange");
+  win.emit("blur");
+  assert.equal(controller.isFocused(), false);
+  win.emit("focus");
+  assert.equal(controller.isInteractive("logs"), true);
+  assert.ok(states.length >= 5);
+
+  controller.destroy();
+  assert.equal(doc.count("visibilitychange"), 0);
+  assert.equal(win.count("focus"), 0);
+  assert.equal(win.count("blur"), 0);
+});
+
+test("mount and no-op state updates are idempotent", () => {
+  const doc = eventTarget({ visibilityState: "visible", hasFocus: () => true });
+  const win = eventTarget();
+  const controller = createActivityController({ document: doc, window: win });
+  let notifications = 0;
+  controller.subscribe(() => notifications++);
+  controller.mount();
+  controller.mount();
+  controller.setView("home");
+  doc.emit("visibilitychange");
+
+  assert.equal(doc.count("visibilitychange"), 1);
+  assert.equal(win.count("focus"), 1);
+  assert.equal(notifications, 2); // immediate subscribe + initial mount snapshot
+});

--- a/tests/performance-observer.test.mjs
+++ b/tests/performance-observer.test.mjs
@@ -1,0 +1,63 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createPerformanceObserver } from "../src/lib/performance-observer.js";
+
+test("collector tracks counters, gauges and bounded samples", () => {
+  let wall = 1000;
+  const observer = createPerformanceObserver({
+    sampleCap: 2,
+    clock: () => 50,
+    wallClock: () => wall++,
+  });
+
+  assert.equal(observer.increment("ipc.calls"), 1);
+  assert.equal(observer.increment("ipc.calls", 2), 3);
+  assert.equal(observer.gauge("window.visible", true), 1);
+  observer.sample("render.ms", 1);
+  observer.sample("render.ms", 2);
+  observer.sample("render.ms", 3, { view: "home" });
+
+  const snapshot = observer.snapshot();
+  assert.equal(snapshot.schemaVersion, 1);
+  assert.equal(snapshot.counters["ipc.calls"], 3);
+  assert.equal(snapshot.gauges["window.visible"], 1);
+  assert.deepEqual(snapshot.samples["render.ms"].map((x) => x.value), [2, 3]);
+  assert.deepEqual(snapshot.samples["render.ms"][1].meta, { view: "home" });
+});
+
+test("marks and one-shot timers record durations", () => {
+  let monotonic = 10;
+  const observer = createPerformanceObserver({
+    clock: () => monotonic,
+    wallClock: () => 500,
+  });
+
+  observer.mark("startup.begin");
+  monotonic = 25;
+  observer.mark("startup.ready");
+  observer.measure("startup.ms", "startup.begin", "startup.ready");
+
+  monotonic = 40;
+  const finish = observer.time("ipc.ms", { command: "health_snapshot" });
+  monotonic = 46;
+  finish();
+  monotonic = 99;
+  assert.equal(finish(), null);
+
+  const snapshot = observer.snapshot();
+  assert.equal(snapshot.samples["startup.ms"][0].value, 15);
+  assert.equal(snapshot.samples["ipc.ms"][0].value, 6);
+  assert.deepEqual(snapshot.samples["ipc.ms"][0].meta, { command: "health_snapshot" });
+});
+
+test("disabled collector is a no-op", () => {
+  const observer = createPerformanceObserver({ enabled: false });
+  observer.increment("x");
+  observer.gauge("y", 1);
+  observer.sample("z", 1);
+  observer.mark("a");
+  assert.deepEqual(observer.snapshot().counters, {});
+  assert.deepEqual(observer.snapshot().gauges, {});
+  assert.deepEqual(observer.snapshot().samples, {});
+});

--- a/tests/telemetry-cache.test.mjs
+++ b/tests/telemetry-cache.test.mjs
@@ -1,0 +1,46 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createTelemetryCache } from "../src/lib/telemetry-cache.js";
+
+test("cache reuses fresh values and expires by TTL", async () => {
+  let now = 100;
+  let calls = 0;
+  const cache = createTelemetryCache({ clock: () => now });
+  const load = async () => ++calls;
+
+  assert.equal(await cache.get("proxies:9090", load, { ttlMs: 1000 }), 1);
+  assert.equal(await cache.get("proxies:9090", load, { ttlMs: 1000 }), 1);
+  assert.equal(calls, 1);
+
+  now = 1200;
+  assert.equal(await cache.get("proxies:9090", load, { ttlMs: 1000 }), 2);
+  assert.equal(calls, 2);
+});
+
+test("concurrent requests join one loader", async () => {
+  let release;
+  let calls = 0;
+  const cache = createTelemetryCache();
+  const loader = () => {
+    calls++;
+    return new Promise((resolve) => { release = resolve; });
+  };
+
+  const a = cache.get("connections", loader, { ttlMs: 0 });
+  const b = cache.get("connections", loader, { ttlMs: 0, force: true });
+  await Promise.resolve();
+  assert.equal(calls, 1);
+  release([1, 2, 3]);
+  assert.deepEqual(await a, [1, 2, 3]);
+  assert.deepEqual(await b, [1, 2, 3]);
+});
+
+test("prefix invalidation only removes matching telemetry", async () => {
+  const cache = createTelemetryCache();
+  await cache.get("proxies:9090", async () => "p", { ttlMs: 1000 });
+  await cache.get("connections:9090", async () => "c", { ttlMs: 1000 });
+  cache.invalidate("proxies:");
+  assert.equal(cache.peek("proxies:9090"), undefined);
+  assert.equal(cache.peek("connections:9090"), "c");
+});


### PR DESCRIPTION
## Что сделано
- добавлен TTL + single-flight cache для `/proxies`, `/connections` и traffic totals;
- cache key включает port и runtime generation;
- cache очищается при смене runtime и инвалидируется после node/group tests и selector mutation;
- traffic meter переведён с прямого invoke на общий telemetry layer;
- добавлены bounded performance timings/counters и unit-тесты cache semantics.

## Эффект
Home и Proxies делят свежий `/proxies` snapshot, а конкурентные consumers каждой telemetry-операции объединяются в один IPC-вызов. Traffic meter больше не обходит общий runtime-aware wrapper. Полное объединение backend-разборов `/connections` для traffic totals и routing monitor оставлено отдельным низкоуровневым этапом после профилировки payload-size.

## Проверка
- `npm test`
- `npm run lint`

Стек PR: 3/7. Base: PR #67.