### PR TITLE
perf: reduce log viewer parsing and background work

### DIFF
--- a/src/lib/activity-controller.js
+++ b/src/lib/activity-controller.js
@@ -1,0 +1,97 @@
+// Ninety · foreground/background activity controller.
+//
+// Visual modules subscribe to this store instead of running independent work
+// while WebView2 is hidden in the tray. Network safety watchdogs remain outside
+// this controller and continue to run regardless of window visibility.
+
+import { perfObserver } from "/lib/performance-observer.js";
+
+function readVisible(doc) {
+  return !doc || doc.visibilityState !== "hidden";
+}
+
+export function createActivityController({
+  document: doc = globalThis.document,
+  window: win = globalThis.window,
+  initialView = "home",
+} = {}) {
+  let state = Object.freeze({
+    visible: readVisible(doc),
+    focused: typeof doc?.hasFocus === "function" ? !!doc.hasFocus() : true,
+    view: initialView,
+  });
+  const listeners = new Set();
+  let mounted = false;
+
+  function notify(previous) {
+    perfObserver.gauge("activity.visible", state.visible ? 1 : 0);
+    perfObserver.gauge("activity.focused", state.focused ? 1 : 0);
+    for (const listener of [...listeners]) {
+      try { listener(state, previous); } catch (error) {
+        console.warn("activity listener failed", error);
+      }
+    }
+  }
+
+  function patch(next) {
+    const candidate = { ...state, ...next };
+    if (candidate.visible === state.visible
+      && candidate.focused === state.focused
+      && candidate.view === state.view) return state;
+    const previous = state;
+    state = Object.freeze(candidate);
+    notify(previous);
+    return state;
+  }
+
+  const onVisibility = () => patch({ visible: readVisible(doc) });
+  const onFocus = () => patch({ focused: true });
+  const onBlur = () => patch({ focused: false });
+
+  function mount() {
+    if (mounted) return;
+    mounted = true;
+    doc?.addEventListener?.("visibilitychange", onVisibility);
+    win?.addEventListener?.("focus", onFocus);
+    win?.addEventListener?.("blur", onBlur);
+    notify(state);
+  }
+
+  function destroy() {
+    if (!mounted) return;
+    mounted = false;
+    doc?.removeEventListener?.("visibilitychange", onVisibility);
+    win?.removeEventListener?.("focus", onFocus);
+    win?.removeEventListener?.("blur", onBlur);
+    listeners.clear();
+  }
+
+  function subscribe(listener, { immediate = true } = {}) {
+    if (typeof listener !== "function") return () => {};
+    listeners.add(listener);
+    if (immediate) listener(state, state);
+    return () => listeners.delete(listener);
+  }
+
+  function setView(view) {
+    if (typeof view === "string" && view) patch({ view });
+  }
+
+  function isInteractive(view = null) {
+    return state.visible && state.focused && (!view || state.view === view);
+  }
+
+  return {
+    mount,
+    destroy,
+    subscribe,
+    setView,
+    snapshot: () => state,
+    isVisible: () => state.visible,
+    isFocused: () => state.focused,
+    isInteractive,
+  };
+}
+
+export const activityController = createActivityController();
+activityController.mount();

--- a/src/lib/clash-api.js
+++ b/src/lib/clash-api.js
@@ -1,14 +1,21 @@
 // Тонкий JS-wrapper над Tauri-командами clash-API.
 
+import { perfObserver } from "/lib/performance-observer.js";
+import { createTelemetryCache } from "/lib/telemetry-cache.js";
+
 const invoke = window.__TAURI__?.core?.invoke
   ?? (() => Promise.reject(new Error("Tauri invoke недоступен")));
 
 const DEFAULT_PORT = 9090;
 const DEFAULT_URL = "https://www.gstatic.com/generate_204";
+const PROXIES_TTL_MS = 1200;
+const CONNECTIONS_TTL_MS = 800;
+const TRAFFIC_TTL_MS = 800;
 
 let runtimeProvider = null;
 let selectionRevision = 0;
 let selectionQueue = Promise.resolve();
+const telemetryCache = createTelemetryCache();
 
 export class ClashApiError extends Error {
   constructor(operation, message, { port, processGeneration } = {}) {
@@ -23,6 +30,7 @@ export class ClashApiError extends Error {
 
 export function configureClashRuntime(provider) {
   runtimeProvider = provider || null;
+  telemetryCache.clear();
 }
 
 function captureRuntime(explicitToken) {
@@ -37,9 +45,20 @@ function assertRuntime(token, operation) {
   if (token && runtimeProvider?.assertCurrent) runtimeProvider.assertCurrent(token, operation);
 }
 
+function telemetryKey(operation, port, token) {
+  return `${operation}:${port}:${token?.processGeneration ?? "none"}`;
+}
+
+export function invalidateClashTelemetry(scope = null) {
+  if (!scope) telemetryCache.invalidate();
+  else telemetryCache.invalidate(`${scope}:`);
+}
+
 async function call(operation, command, args, { token } = {}) {
   const captured = captureRuntime(token);
   const port = runtimePort(args.port, captured);
+  const finish = perfObserver.time("clash.ipc.ms", { operation, port });
+  perfObserver.increment("clash.ipc.calls");
   try {
     assertRuntime(captured, operation);
     const value = await invoke(command, { ...args, port });
@@ -51,13 +70,29 @@ async function call(operation, command, args, { token } = {}) {
       port,
       processGeneration: captured?.processGeneration,
     });
+  } finally {
+    finish();
   }
 }
 
+async function cachedCall(operation, command, args, options, ttlMs) {
+  const captured = captureRuntime(options?.token);
+  const port = runtimePort(args.port, captured);
+  const key = telemetryKey(operation, port, captured);
+  const cached = telemetryCache.peek(key);
+  if (!options?.fresh && cached !== undefined) perfObserver.increment(`clash.cache.peek.${operation}`);
+  return telemetryCache.get(
+    key,
+    () => call(operation, command, { ...args, port }, { token: captured }),
+    { ttlMs, force: options?.fresh === true },
+  );
+}
+
 export async function getProxies(port, options = {}) {
-  const value = await call("getProxies", "clash_get_proxies", { port }, options);
+  const value = await cachedCall("proxies", "clash_get_proxies", { port }, options, PROXIES_TTL_MS);
   if (!value || typeof value !== "object" || !value.proxies || typeof value.proxies !== "object") {
     const token = captureRuntime(options.token);
+    invalidateClashTelemetry("proxies");
     throw new ClashApiError("getProxies", "невалидная структура ответа", {
       port: runtimePort(port, token), processGeneration: token?.processGeneration,
     });
@@ -67,16 +102,43 @@ export async function getProxies(port, options = {}) {
 
 // Живые соединения для монитора правил маршрутизации:
 // [{ process, processPath, host, destinationIP, outbound:"direct"|"proxy"|"block" }].
-// Процесс резолвится у каждого соединения (в конфиге есть форсирующее
-// process-правило → sing-box ищет владельца сокета на каждом коннекте). Форк шлёт
-// только processPath; имя (process) Rust выводит как basename пути. process=null
-// лишь для соединений, у которых ОС не отдала владельца сокета (системные и т.п.).
+// Все одновременные consumers делят один IPC/HTTP snapshot в пределах TTL.
 export async function getConnections(port, options = {}) {
-  const value = await call("getConnections", "clash_get_connections", { port }, options);
-  if (!Array.isArray(value)) throw new ClashApiError("getConnections", "ожидался массив", {
-    port: runtimePort(port, captureRuntime(options.token)),
-  });
+  const value = await cachedCall(
+    "connections",
+    "clash_get_connections",
+    { port },
+    options,
+    CONNECTIONS_TTL_MS,
+  );
+  if (!Array.isArray(value)) {
+    invalidateClashTelemetry("connections");
+    throw new ClashApiError("getConnections", "ожидался массив", {
+      port: runtimePort(port, captureRuntime(options.token)),
+    });
+  }
   return value;
+}
+
+// Кумулятивные totals ядра. traffic-meter использует тот же single-flight слой,
+// поэтому параллельный тик не создаёт второй /connections request.
+export async function getTrafficTotal(port, options = {}) {
+  const value = await cachedCall(
+    "traffic",
+    "clash_traffic_total",
+    { port },
+    options,
+    TRAFFIC_TTL_MS,
+  );
+  const up = Number(value?.up);
+  const down = Number(value?.down);
+  if (!Number.isFinite(up) || !Number.isFinite(down)) {
+    invalidateClashTelemetry("traffic");
+    throw new ClashApiError("getTrafficTotal", "ожидались числовые up/down", {
+      port: runtimePort(port, captureRuntime(options.token)),
+    });
+  }
+  return { up, down };
 }
 
 // Процессы с исходящей сетевой активностью (для выбора при создании правила):
@@ -86,11 +148,15 @@ export async function listNetworkProcesses() {
 }
 
 export async function testNode(name, { port, url = DEFAULT_URL, timeoutMs = 5000, token } = {}) {
-  return call("testNode", "clash_test_node", { port, name, url, timeoutMs }, { token });
+  const value = await call("testNode", "clash_test_node", { port, name, url, timeoutMs }, { token });
+  invalidateClashTelemetry("proxies");
+  return value;
 }
 
 export async function testGroup(group, { port, url = DEFAULT_URL, timeoutMs = 5000, token } = {}) {
-  return call("testGroup", "clash_test_group", { port, group, url, timeoutMs }, { token });
+  const value = await call("testGroup", "clash_test_group", { port, group, url, timeoutMs }, { token });
+  invalidateClashTelemetry("proxies");
+  return value;
 }
 
 // Замер задержки эффективной ноды для hero/location-card.
@@ -98,12 +164,7 @@ export async function testGroup(group, { port, url = DEFAULT_URL, timeoutMs = 50
 // Корень бага «в списке 30мс, на главной 100+»: апстрим-форк в обработчике
 // одиночного GET /proxies/{name}/delay меряет через context.Background(), который
 // НЕ несёт box-ctx → IsUnifiedDelayFromContext=false → один HEAD с полным dial+TLS
-// (завышение ~3x). Групповой /group/{name}/delay меряет через r.Context() → unified
-// (чистый второй RTT) → 30мс. min-из-N не спасал: каждый /delay — холодный.
-// Перейти на групповой нельзя — он interval-gated (молчит 600с, не перемеряет) →
-// заморозка. Поэтому в CI одиночный обработчик пропатчен на r.Context() (build.yml):
-// теперь /proxies/{name}/delay тоже unified И перемеряет каждый вызов (без gate) →
-// число совпадает со списком, автозамер и клик живые. Это и есть единый путь здесь.
+// (завышение ~3x). В CI одиночный handler патчится на unified context.
 export async function refreshEffectiveDelay({ port, url = DEFAULT_URL, timeoutMs = 5000, token } = {}) {
   let data;
   try { data = await getProxies(port, { token }); } catch (e) {
@@ -126,8 +187,9 @@ export function selectProxy(group, name, { port, token } = {}) {
     if (revision !== selectionRevision) return { stale: true };
     const captured = captureRuntime(token);
     await call("selectProxy", "clash_select_proxy", { port, group, name }, { token: captured });
+    invalidateClashTelemetry("proxies");
     if (revision !== selectionRevision) return { stale: true };
-    const confirmed = await getProxies(port, { token: captured });
+    const confirmed = await getProxies(port, { token: captured, fresh: true });
     if (revision !== selectionRevision) return { stale: true };
     const actual = confirmed?.proxies?.[group]?.now;
     if (actual !== name) {
@@ -161,7 +223,6 @@ export function pickEffectiveNode(proxiesResp) {
   const sel = proxies.proxy;
   if (!sel) return null;
   if (!sel.now) {
-    // single-mode: "proxy" — это и есть конечный outbound, а не Selector
     return sel.type && sel.type.toLowerCase() === "selector" ? null : "proxy";
   }
   if (sel.now === "auto") {
@@ -170,12 +231,10 @@ export function pickEffectiveNode(proxiesResp) {
   return sel.now;
 }
 
-// Совместимая точка для старого кода — теперь == pickSelectorNow.
 export function pickActiveNode(proxiesResp) {
   return pickSelectorNow(proxiesResp);
 }
 
-// Последний delay по истории
 export function lastDelay(proxyObj) {
   if (!proxyObj) return 0;
   const hist = proxyObj.history;
@@ -186,8 +245,6 @@ export function lastDelay(proxyObj) {
   return 0;
 }
 
-// Hiddify-UX: 0 или >65000 трактуем как "не дотянулись" — "Connecting"/dead.
-// Прочее — числовая градация.
 export function gradeDelay(ms) {
   if (!ms || ms <= 0) return "dead";
   if (ms >= 65000) return "dead";

--- a/src/lib/clash-stream.js
+++ b/src/lib/clash-stream.js
@@ -2,6 +2,9 @@
 // (байт/сек). Также exposed legacy poll-функция для пинга /proxies.
 
 import { getProxies, lastDelay, pickEffectiveNode, refreshEffectiveDelay } from "/lib/clash-api.js";
+import { activityController } from "/lib/activity-controller.js";
+import { createDistinctEmitter } from "/lib/distinct-emitter.js";
+import { perfObserver } from "/lib/performance-observer.js";
 import { t } from "/lib/i18n/index.js";
 
 const invoke = window.__TAURI__?.core?.invoke
@@ -14,7 +17,9 @@ const DEAD_RETEST_MS = 4000;        // мёртвый/0 замер — ожив�
 const WARM_REFRESH_MS = 10000;      // живой замер — периодически освежаем (auto-refresh)
 
 let unlistenTraffic = null;
+let unlistenActivity = null;
 let pingTimer = null;
+let pingPollOnce = null;
 let lastEffectiveTag = null;
 let lastForceTestTs = 0;
 let streamRevision = 0;
@@ -34,9 +39,21 @@ export function createSingleFlightRunner(task) {
   };
 }
 
+function stopPingPolling() {
+  if (pingTimer) { clearInterval(pingTimer); pingTimer = null; }
+}
+
+function startPingPolling() {
+  if (!pingPollOnce || pingTimer || !activityController.isVisible()) return;
+  pingPollOnce();
+  pingTimer = setInterval(pingPollOnce, PING_POLL_MS);
+}
+
 async function stopCurrentStream() {
   if (unlistenTraffic) { try { unlistenTraffic(); } catch {} unlistenTraffic = null; }
-  if (pingTimer) { clearInterval(pingTimer); pingTimer = null; }
+  if (unlistenActivity) { try { unlistenActivity(); } catch {} unlistenActivity = null; }
+  stopPingPolling();
+  pingPollOnce = null;
   lastEffectiveTag = null;
   lastForceTestTs = 0;
   try { await invoke("clash_traffic_stop"); } catch {}
@@ -47,7 +64,8 @@ async function reconcileStream(revision) {
   await stopCurrentStream();
   if (revision !== streamRevision || !desiredStream) return;
   const { port, onTraffic, onPing, onNodeChange } = desiredStream;
-  // подписка на WS-event
+  // подписка на WS-event остаётся активной в трее: она питает traffic meter и
+  // quality engine. Пауза относится только к визуальному ping-поллингу.
   if (eventApi?.listen && onTraffic) {
     const unlisten = await eventApi.listen("clash:traffic", (ev) => {
       if (revision !== streamRevision) return;
@@ -66,20 +84,23 @@ async function reconcileStream(revision) {
   try { await invoke("clash_traffic_start", { port }); } catch (e) {
     console.warn("clash_traffic_start failed", e);
   }
-  // параллельно — пинг-поллинг /proxies для location-card (Hiddify-style: 3с)
+
   if (onPing) {
-    const pollOnce = createSingleFlightRunner(async () => {
-      if (revision !== streamRevision) return;
+    const distinctPing = createDistinctEmitter(onPing, ({ delay, nodeTag }) => `${delay}|${nodeTag || ""}`);
+    const emitPing = (payload) => {
+      if (!distinctPing(payload)) perfObserver.increment("clash.ui.ping.suppressed");
+    };
+
+    pingPollOnce = createSingleFlightRunner(async () => {
+      if (revision !== streamRevision || !activityController.isVisible()) return;
       try {
         const data = await getProxies(port);
-        if (revision !== streamRevision) return;
+        if (revision !== streamRevision || !activityController.isVisible()) return;
         const effective = pickEffectiveNode(data);
         const obj = effective ? data?.proxies?.[effective] : null;
         const d = lastDelay(obj);
-        // Авто-обновление: периодически в ФОНЕ перемеряем эффективную ноду
-        // (refreshEffectiveDelay → одиночный /proxies/{name}/delay, пропатчен на
-        // unified → совпадает со списком), результат отдаём через onPing; сам
-        // поллинг не блокируется. Мёртвое освежаем чаще, живое — раз в WARM_REFRESH_MS.
+        // Авто-обновление: периодически в ФОНЕ перемеряем эффективную ноду.
+        // Когда окно скрыто, визуальная проба не нужна и не запускается.
         const now = Date.now();
         const dead = !d || d <= 0 || d >= 65000;
         const due = effective && (now - lastForceTestTs) > (dead ? DEAD_RETEST_MS : WARM_REFRESH_MS);
@@ -87,7 +108,10 @@ async function reconcileStream(revision) {
           lastForceTestTs = now;
           refreshEffectiveDelay({ port, timeoutMs: 4000 })
             .then((r) => {
-              if (revision === streamRevision && r?.delay > 0 && r.delay < 65000) onPing({ delay: r.delay, nodeTag: r.tag });
+              if (revision === streamRevision && activityController.isVisible()
+                && r?.delay > 0 && r.delay < 65000) {
+                emitPing({ delay: r.delay, nodeTag: r.tag });
+              }
             })
             .catch(() => {});
         }
@@ -95,13 +119,22 @@ async function reconcileStream(revision) {
           lastEffectiveTag = effective;
           try { onNodeChange?.({ tag: effective }); } catch {}
         }
-        onPing({ delay: d, nodeTag: effective });
+        emitPing({ delay: d, nodeTag: effective });
       } catch {
-        if (revision === streamRevision) onPing({ delay: 0, nodeTag: null });
+        if (revision === streamRevision && activityController.isVisible()) {
+          emitPing({ delay: 0, nodeTag: null });
+        }
       }
     });
-    pollOnce();
-    pingTimer = setInterval(pollOnce, PING_POLL_MS);
+
+    unlistenActivity = activityController.subscribe(({ visible }) => {
+      if (revision !== streamRevision) return;
+      if (visible) startPingPolling();
+      else {
+        stopPingPolling();
+        perfObserver.increment("clash.ui.ping.pauses");
+      }
+    });
   }
 }
 

--- a/src/lib/distinct-emitter.js
+++ b/src/lib/distinct-emitter.js
@@ -1,0 +1,24 @@
+// Emits only when the derived payload key changes. Used to avoid repeated DOM
+// updates for telemetry snapshots that are byte-for-byte equivalent.
+
+export function createDistinctEmitter(callback, keyOf = (value) => JSON.stringify(value)) {
+  let hasValue = false;
+  let lastKey;
+
+  function emit(value) {
+    if (typeof callback !== "function") return false;
+    const key = keyOf(value);
+    if (hasValue && Object.is(key, lastKey)) return false;
+    hasValue = true;
+    lastKey = key;
+    callback(value);
+    return true;
+  }
+
+  emit.reset = () => {
+    hasValue = false;
+    lastKey = undefined;
+  };
+
+  return emit;
+}

--- a/src/lib/hero-hud.js
+++ b/src/lib/hero-hud.js
@@ -7,13 +7,13 @@
 //      clock y=60→106, INTEGRITY y=330→298, ERR y=350→372.  (раньше всё было свалено
 //      в один 20px-пятак внизу + часы лезли на дугу SYSTEM STATUS).
 //   2) Анимация HUD больше НЕ глушится prefers-reduced-motion: вращение колец, глитч,
-//      INTEGRITY/ERR/blink работают всегда. HUD — смысловой центр экрана, а не декор;
-//      при выключенных в Windows анимациях он раньше полностью замерзал (играла только
-//      видео-маска). Если нужна строгая a11y — погасите .hud__outer/seg/ticks в app.css.
+//      INTEGRITY/ERR/blink работают всегда, пока окно действительно видно. В трее
+//      визуальная телеметрия полностью ставится на паузу через activity-controller.
 //   3) Вращение колец перенесено с rAF+setAttribute('transform') на CSS-анимацию,
 //      идущую на компоновщике (GPU): слой растрится один раз, дальше только крутится.
-//      Это убирает покадровую перерисовку всего SVG (была причина высокой нагрузки на
-//      GPU-процесс WebView2 на главном экране). Скорости/направления не изменились.
+
+import { activityController } from "/lib/activity-controller.js";
+import { perfObserver } from "/lib/performance-observer.js";
 
 const CX = 200, CY = 200;
 const P = (deg, r) => [CX + Math.cos((deg * Math.PI) / 180) * r, CY + Math.sin((deg * Math.PI) / 180) * r];
@@ -96,14 +96,23 @@ const ERR_OFFLINE = ["NO LINK", "SEARCHING…", "ERR_ON_KNW"];
 const pad = (n) => String(n).padStart(2, "0");
 
 // getState() → 'secured' | 'linking' | 'standby'.  getTarget() → строка-тег сервера или null.
-export function initHeroHud(svg, { getState, getTarget } = {}) {
+export function initHeroHud(svg, { getState, getTarget, activity = activityController } = {}) {
   if (!svg) return { destroy() {} };
   svg.innerHTML = buildHud();
   const els = {};
   svg.querySelectorAll("[data-hud]").forEach((el) => { els[el.dataset.hud] = el; });
 
   const st = () => (getState?.() || "standby");
-  let timers = [], intgVal = 0, ei = 0, clockStr = "";
+  let timers = [], transientTimers = [], intgVal = 0, ei = 0, clockStr = "";
+  let running = false;
+
+  function later(fn, ms) {
+    const id = setTimeout(() => {
+      transientTimers = transientTimers.filter((value) => value !== id);
+      if (running) fn();
+    }, ms);
+    transientTimers.push(id);
+  }
 
   function updClock() {
     const d = new Date();
@@ -121,7 +130,7 @@ export function initHeroHud(svg, { getState, getTarget } = {}) {
   function blink() {
     if (!els.sys) return;
     els.sys.setAttribute("opacity", "0.18");
-    setTimeout(() => els.sys && els.sys.setAttribute("opacity", "1"), 105);
+    later(() => els.sys?.setAttribute("opacity", "1"), 105);
   }
   function cycleErr() {
     if (!els.err) return;
@@ -132,15 +141,13 @@ export function initHeroHud(svg, { getState, getTarget } = {}) {
     els.err.style.fill = sec ? "var(--text-lo)" : "var(--err)";
   }
   function glitch() {
-    // Для светлых тем аберрация и резкое затемнение SVG выглядят как артефакт,
-    // а не как телеметрия. Кольца и живые показатели при этом остаются.
     if (["shiro", "sakura"].includes(document.documentElement.dataset.theme)) return;
     if (Math.random() > 0.6) return;
     const g = els.ca; if (!g) return;
     g.setAttribute("transform", "translate(3,-1) skewX(-3)");
     svg.style.opacity = "0.55";
-    setTimeout(() => g && g.setAttribute("transform", "translate(-2,1)"), 65);
-    setTimeout(() => { if (g) g.setAttribute("transform", ""); svg.style.opacity = ""; }, 150);
+    later(() => g?.setAttribute("transform", "translate(-2,1)"), 65);
+    later(() => { if (g) g.setAttribute("transform", ""); svg.style.opacity = ""; }, 150);
   }
 
   function sync() {
@@ -153,22 +160,49 @@ export function initHeroHud(svg, { getState, getTarget } = {}) {
     cycleErr();
   }
 
-  // Вращение колец (outer/seg/ticks) теперь живёт в CSS на компоновщике
-  // (см. .hud__outer/seg/ticks + @keyframes hud-spin в app.css) — без покадровой
-  // перерисовки SVG. Здесь остаются только редкие точечные обновления
-  // (часы/INTEGRITY/ERR/глитч) на setInterval. HUD анимируется ВСЕГДА.
-  updClock(); sync();
-  timers.push(setInterval(updClock, 1000));
-  timers.push(setInterval(updIntegrity, 1600));
-  timers.push(setInterval(blink, 1500));
-  timers.push(setInterval(cycleErr, 2400));
-  timers.push(setInterval(glitch, 4000));
+  function setCssAnimationState(value) {
+    for (const key of ["outer", "seg", "ticks"]) {
+      if (els[key]) els[key].style.animationPlayState = value;
+    }
+  }
+
+  function stopTimers() {
+    if (!running) return;
+    running = false;
+    timers.forEach(clearInterval);
+    timers = [];
+    transientTimers.forEach(clearTimeout);
+    transientTimers = [];
+    setCssAnimationState("paused");
+    perfObserver.increment("hud.pauses");
+  }
+
+  function startTimers() {
+    if (running) return;
+    running = true;
+    setCssAnimationState("running");
+    updClock();
+    sync();
+    timers.push(setInterval(updClock, 1000));
+    timers.push(setInterval(updIntegrity, 1600));
+    timers.push(setInterval(blink, 1500));
+    timers.push(setInterval(cycleErr, 2400));
+    timers.push(setInterval(glitch, 4000));
+    perfObserver.increment("hud.resumes");
+  }
+
+  const unsubscribe = activity?.subscribe?.((snapshot) => {
+    if (snapshot.visible) startTimers();
+    else stopTimers();
+  }) || (() => {});
+
+  if (!activity?.subscribe) startTimers();
 
   return {
     sync,
     destroy() {
-      timers.forEach(clearInterval);
-      timers = [];
+      unsubscribe();
+      stopTimers();
     },
   };
 }

--- a/src/lib/logs-view.js
+++ b/src/lib/logs-view.js
@@ -4,6 +4,8 @@
 // mountLogsView() на старте, onLogsViewEnter/Leave при навигации и
 // rerenderLogsView() при смене языка.
 
+import { activityController } from "/lib/activity-controller.js";
+import { perfObserver } from "/lib/performance-observer.js";
 import { t } from "/lib/i18n/index.js";
 import { toast } from "/lib/toast.js";
 import { FLAGS_BASE, flagIsoFromName as isoFromNodeName } from "/lib/flags.js";
@@ -22,8 +24,12 @@ let logsView, logsPath, logsSize, logsAuto, logsRefreshBtn, logsCopyBtn,
 let logsTimer = null;
 let logsActive = false;
 let logsLastValue = "";
+let logsEntries = [];
+let logsLastRenderedHtml = null;
 let logsFilterQuery = "";
 let logsFilterLevel = "";
+let searchDebounceTimer = null;
+let unlistenActivity = null;
 
 function currentLogSource() { return logsSource?.value || "singbox"; }
 
@@ -37,12 +43,7 @@ function formatBytes(n) {
 //                  `12:34:56.123 INFO message`           (timestamp без даты)
 //                  `INFO message`                        (timestamp выключен)
 //                  `+0300 INFO message`                  (offset без timestamp)
-// Группы: 1=offset, 2=date, 3=time, 4=level, 5=rest
 const LOG_LINE_RE = /^(?:([+-]\d{4})\s+)?(?:(\d{4}-\d{2}-\d{2})\s+)?(\d{1,2}:\d{2}:\d{2}(?:\.\d+)?)?\s*(TRACE|DEBUG|INFO|WARN|WARNING|ERROR|FATAL|PANIC)\s+(.*)$/i;
-
-// sing-box/xray льют в stderr с ANSI-цветами, а капча процессов префиксует строку
-// «STDERR: »/«STDOUT: ». И то и другое сбивает LOG_LINE_RE (уровень обёрнут в \x1b[..m,
-// якорь ^ упирается в префикс) → строка падала в сырьё. Снимаем перед парсингом.
 const LOG_ANSI_RE = /\x1b\[[0-9;]*m/g;        // eslint-disable-line no-control-regex
 const LOG_STD_PREFIX_RE = /^(?:STDERR|STDOUT):\s*/;
 function cleanLogLine(s) { return s.replace(LOG_ANSI_RE, "").replace(LOG_STD_PREFIX_RE, ""); }
@@ -61,22 +62,16 @@ function escapeLog(s) {
 
 function highlightMessage(msg) {
   const safe = escapeLog(msg);
-  // tag в [скобках] подсветить; если в теге узнаётся страна (имя ноды
-  // «node-17-Latvia-…») — вклеиваем флаг той же логикой, что на экране Нод.
-  // Служебные скобки ([mixed-in], [3589469481 0ms], [direct]) флага не дают —
-  // flagIsoFromName на них возвращает null. Фолбэк битого .svg — attachLogFlagFallbacks.
   return safe
     .replace(/\[([^\]]+)\]/g, (_m, tag) => {
       const iso = isoFromNodeName(tag);
-      const flag = iso ? `<img class="log-flag" src="${FLAGS_BASE}/${iso}.svg" alt="">` : '';
+      const flag = iso ? `<img class="log-flag" src="${FLAGS_BASE}/${iso}.svg" alt="">` : "";
       return `<b>[${flag}${tag}]</b>`;
     })
     .replace(/\b(\d+\.\d+\.\d+\.\d+)(?::\d+)?\b/g, '<span class="acc">$&</span>')
     .replace(/\b(?:wss?|https?):\/\/[^\s]+/gi, '<span class="acc">$&</span>');
 }
 
-// CSP-safe фолбэк для флагов в логах (inline onerror блокируется): битый .svg
-// просто убираем — остаётся обычный тег ноды. Зовётся после каждого рендера лога.
 function attachLogFlagFallbacks(root) {
   if (!root) return;
   for (const img of root.querySelectorAll("img.log-flag")) {
@@ -86,51 +81,46 @@ function attachLogFlagFallbacks(root) {
 }
 
 const LOG_RENDER_MAX_LINES = 800;
-// Уровень из дропдауна → набор токенов лога. WARN/WARNING и ERROR/FATAL/PANIC
-// группируются, чтобы «warn»/«error» ловили все варианты.
 const LOG_LEVEL_GROUP = {
   trace: ["TRACE"], debug: ["DEBUG"], info: ["INFO"],
   warn: ["WARN", "WARNING"], error: ["ERROR", "FATAL", "PANIC"],
 };
 
-// Парс текста лога в структурные записи (с прилепленными многострочными
-// продолжениями) — нужно, чтобы фильтр по уровню/тексту работал по записи
-// целиком, не разрывая мульти-line сообщения.
-function parseLogEntries(text) {
-  const lines = text.split(/\r?\n/).slice(-LOG_RENDER_MAX_LINES);
+// Парс выполняется только при получении нового file tail. Изменение search/level
+// фильтрует уже готовые entries и больше не split/regex-парсит 800 строк заново.
+export function parseLogEntries(text) {
+  const lines = String(text || "").split(/\r?\n/).slice(-LOG_RENDER_MAX_LINES);
   const entries = [];
   let cur = null;
   for (const raw0 of lines) {
     const raw = cleanLogLine(raw0);
-    if (!raw) { if (cur) cur.cont.push(''); continue; }
+    if (!raw) { if (cur) cur.cont.push(""); continue; }
     const m = LOG_LINE_RE.exec(raw);
     if (m) {
       const [, , date, time, level, rest] = m;
-      // НЕ называть локальную переменную t — затенила бы i18n-функцию (см.
-      // прецедент R3 в quality-actions).
-      const tm = time || (date ? date.slice(5) : '—');
+      const tm = time || (date ? date.slice(5) : "—");
       const lvl = level.toUpperCase();
       cur = { t: tm, lvl, grade: levelGrade(lvl), msg: rest, cont: [] };
       entries.push(cur);
     } else if (cur) {
       cur.cont.push(raw);
     } else {
-      cur = { t: '—', lvl: '', grade: 'info', msg: raw, cont: [] };
+      cur = { t: "—", lvl: "", grade: "info", msg: raw, cont: [] };
       entries.push(cur);
     }
   }
   return entries;
 }
 
-function filterLogEntries(entries) {
-  const group = logsFilterLevel ? LOG_LEVEL_GROUP[logsFilterLevel] : null;
-  const words = logsFilterQuery ? logsFilterQuery.split(/\s+/).filter(Boolean) : [];
+export function filterLogEntries(entries, query = logsFilterQuery, level = logsFilterLevel) {
+  const group = level ? LOG_LEVEL_GROUP[level] : null;
+  const words = query ? query.split(/\s+/).filter(Boolean) : [];
   if (!group && !words.length) return entries;
-  return entries.filter(e => {
-    if (group && !group.includes(e.lvl)) return false;
+  return entries.filter((entry) => {
+    if (group && !group.includes(entry.lvl)) return false;
     if (words.length) {
-      const hay = `${e.t} ${e.lvl} ${e.msg} ${e.cont.join(' ')}`.toLowerCase();
-      if (!words.every(w => hay.includes(w))) return false;
+      const hay = `${entry.t} ${entry.lvl} ${entry.msg} ${entry.cont.join(" ")}`.toLowerCase();
+      if (!words.every((word) => hay.includes(word))) return false;
     }
     return true;
   });
@@ -138,43 +128,53 @@ function filterLogEntries(entries) {
 
 function renderLogEntries(entries) {
   const out = [];
-  for (const e of entries) {
-    const lvlDisp = e.lvl || '···';
-    const tail = e.cont.length ? escapeLog('\n' + e.cont.join('\n')) : '';
-    out.push(`<div class="log-line"><span class="log-line__t">${escapeLog(e.t)}</span><span class="log-line__l log-line__l--${e.grade}">${lvlDisp}</span><span class="log-line__m">${highlightMessage(e.msg)}${tail}</span></div>`);
+  for (const entry of entries) {
+    const lvlDisp = entry.lvl || "···";
+    const tail = entry.cont.length ? escapeLog("\n" + entry.cont.join("\n")) : "";
+    out.push(`<div class="log-line"><span class="log-line__t">${escapeLog(entry.t)}</span><span class="log-line__l log-line__l--${entry.grade}">${lvlDisp}</span><span class="log-line__m">${highlightMessage(entry.msg)}${tail}</span></div>`);
   }
-  return out.join('');
+  return out.join("");
 }
 
 function logsInfoLine(text) {
   return `<div class="log-line"><span class="log-line__t">—</span><span class="log-line__l log-line__l--info">···</span><span class="log-line__m" style="font-style:italic;color:var(--text-faint)">${escapeLog(text)}</span></div>`;
 }
 
-// Рендер из кэша (logsLastValue) с учётом фильтров — зовётся и при обновлении
-// лога, и при смене фильтра (без повторного чтения файла).
-function applyLogsRender({ keepScroll = false } = {}) {
+function applyLogsRender({ keepScroll = false, force = false } = {}) {
   if (!logsView) return;
   const text = logsLastValue && logsLastValue !== "__force__" ? logsLastValue : "";
   const atBottom = !keepScroll || (logsView.scrollTop + logsView.clientHeight >= logsView.scrollHeight - 24);
+  let html;
   if (!text) {
     const label = LOG_SOURCE_LABEL[currentLogSource()] || t("logs.compFallback");
-    logsView.innerHTML = logsInfoLine(t("logs.empty", { comp: label }));
+    html = logsInfoLine(t("logs.empty", { comp: label }));
   } else {
-    const filtered = filterLogEntries(parseLogEntries(text));
-    logsView.innerHTML = filtered.length
-      ? renderLogEntries(filtered)
-      : logsInfoLine(t("logs.notFound"));
+    const filtered = filterLogEntries(logsEntries);
+    html = filtered.length ? renderLogEntries(filtered) : logsInfoLine(t("logs.notFound"));
+  }
+
+  if (force || html !== logsLastRenderedHtml) {
+    const finish = perfObserver.time("logs.render.ms", { entries: logsEntries.length });
+    logsView.innerHTML = html;
+    logsLastRenderedHtml = html;
     attachLogFlagFallbacks(logsView);
+    finish();
+  } else {
+    perfObserver.increment("logs.render.suppressed");
   }
   if (atBottom) logsView.scrollTop = logsView.scrollHeight;
 }
 
 async function refreshLogs({ keepScroll = false } = {}) {
-  if (!logsView) return;
+  if (!logsView || !activityController.isVisible()) return;
   try {
+    const finish = perfObserver.time("logs.read.ms", { source: currentLogSource() });
     const text = await invoke("read_log", { source: currentLogSource(), tailBytes: 256 * 1024 });
+    finish();
     if (text === logsLastValue) return;
     logsLastValue = text;
+    logsEntries = parseLogEntries(text);
+    logsLastRenderedHtml = null;
     if (logsSize) {
       const bytes = new TextEncoder().encode(text || "").length;
       logsSize.textContent = text ? formatBytes(bytes) : t("logs.sizeEmpty");
@@ -189,9 +189,6 @@ async function refreshLogsPath() {
   if (!logsPath) return;
   try {
     const path = await invoke("singbox_log_path");
-    // Показываем ПАПКУ журналов, а не singbox.log: в ней лежат логи всех
-    // компонентов (sing-box, xray, naive, trusttunnel, dpi). Кнопка «Папка»
-    // её открывает. В консоли ниже — лог ядра sing-box.
     const dir = path.replace(/[\\/][^\\/]*$/, "");
     logsPath.textContent = dir;
     logsPath.title = t("logs.pathTitle");
@@ -202,7 +199,7 @@ async function refreshLogsPath() {
 
 function startLogsAuto() {
   stopLogsAuto();
-  if (!logsAuto?.checked) return;
+  if (!logsAuto?.checked || !logsActive || !activityController.isVisible()) return;
   logsTimer = setInterval(() => refreshLogs({ keepScroll: true }), 2000);
 }
 
@@ -212,6 +209,12 @@ function stopLogsAuto() {
 
 function applyKicker() {
   if (logsKicker) logsKicker.textContent = `${t("logs.kicker")} · ${LOG_SOURCE_LABEL[currentLogSource()] || "—"}`;
+}
+
+function resetLogCache() {
+  logsLastValue = "__force__";
+  logsEntries = [];
+  logsLastRenderedHtml = null;
 }
 
 export function mountLogsView() {
@@ -228,6 +231,19 @@ export function mountLogsView() {
   logsSource = document.getElementById("logs-source");
   logsKicker = document.getElementById("logs-kicker");
 
+  if (!unlistenActivity) {
+    unlistenActivity = activityController.subscribe(({ visible }) => {
+      if (!logsActive) return;
+      if (visible) {
+        refreshLogs({ keepScroll: true });
+        startLogsAuto();
+      } else {
+        stopLogsAuto();
+        perfObserver.increment("logs.auto.pauses");
+      }
+    });
+  }
+
   logsAuto?.addEventListener("change", () => {
     if (logsActive && logsAuto.checked) startLogsAuto();
     else stopLogsAuto();
@@ -236,8 +252,12 @@ export function mountLogsView() {
   logsRefreshBtn?.addEventListener("click", () => refreshLogs());
 
   logsSearch?.addEventListener("input", () => {
-    logsFilterQuery = logsSearch.value.trim().toLowerCase();
-    applyLogsRender();
+    if (searchDebounceTimer) clearTimeout(searchDebounceTimer);
+    searchDebounceTimer = setTimeout(() => {
+      searchDebounceTimer = null;
+      logsFilterQuery = logsSearch.value.trim().toLowerCase();
+      applyLogsRender();
+    }, 120);
   });
 
   logsLevel?.addEventListener("change", () => {
@@ -247,14 +267,13 @@ export function mountLogsView() {
 
   logsSource?.addEventListener("change", () => {
     applyKicker();
-    logsLastValue = "__force__"; // сменился источник — перечитать файл и перерисовать
+    resetLogCache();
     refreshLogs();
   });
 
   logsCopyBtn?.addEventListener("click", async () => {
     const raw = logsLastValue && logsLastValue !== "__force__" ? logsLastValue : "";
     if (!raw) { toast(t("logs.emptyToast"), "info", 1400); return; }
-    // копируем без ANSI/префиксов — ровно то, что на экране, а не управляющие коды
     const text = raw.split(/\r?\n/).map(cleanLogLine).join("\n");
     try {
       await navigator.clipboard.writeText(text);
@@ -267,7 +286,7 @@ export function mountLogsView() {
   logsClearBtn?.addEventListener("click", async () => {
     try {
       await invoke("clear_log", { source: currentLogSource() });
-      logsLastValue = "__force__";
+      resetLogCache();
       await refreshLogs();
       toast(t("logs.cleared"), "info", 1400);
     } catch (e) {
@@ -291,12 +310,14 @@ export function onLogsViewEnter() {
 export function onLogsViewLeave() {
   logsActive = false;
   stopLogsAuto();
+  if (searchDebounceTimer) { clearTimeout(searchDebounceTimer); searchDebounceTimer = null; }
 }
 
 // Смена языка интерфейса: перерисовать кикер/контент/путь, если экран активен.
 export function rerenderLogsView() {
   if (!logsActive) return;
   applyKicker();
-  applyLogsRender({ keepScroll: true });
+  logsLastRenderedHtml = null;
+  applyLogsRender({ keepScroll: true, force: true });
   refreshLogsPath();
 }

--- a/src/lib/performance-observer.js
+++ b/src/lib/performance-observer.js
@@ -1,0 +1,127 @@
+// Ninety · lightweight performance observability.
+//
+// The collector is intentionally dependency-free and safe for production builds:
+// callers opt in explicitly, samples are bounded, and snapshots contain only
+// timings/counters (never profile URLs, node credentials or destinations).
+
+const DEFAULT_SAMPLE_CAP = 120;
+
+function finiteNumber(value, fallback = 0) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function nowMs(clock) {
+  try { return finiteNumber(clock?.(), Date.now()); }
+  catch { return Date.now(); }
+}
+
+export function createPerformanceObserver({
+  enabled = true,
+  sampleCap = DEFAULT_SAMPLE_CAP,
+  clock = () => globalThis.performance?.now?.() ?? Date.now(),
+  wallClock = () => Date.now(),
+} = {}) {
+  const cap = Math.max(1, Math.min(1000, Math.trunc(finiteNumber(sampleCap, DEFAULT_SAMPLE_CAP))));
+  const counters = new Map();
+  const gauges = new Map();
+  const samples = new Map();
+  const marks = new Map();
+  const startedAt = nowMs(wallClock);
+
+  function active() { return enabled === true; }
+
+  function increment(name, amount = 1) {
+    if (!active() || !name) return 0;
+    const next = finiteNumber(counters.get(name)) + finiteNumber(amount, 1);
+    counters.set(String(name), next);
+    return next;
+  }
+
+  function gauge(name, value) {
+    if (!active() || !name) return 0;
+    const next = finiteNumber(value);
+    gauges.set(String(name), next);
+    return next;
+  }
+
+  function sample(name, value, meta = null) {
+    if (!active() || !name) return null;
+    const entry = {
+      at: nowMs(wallClock),
+      value: finiteNumber(value),
+      ...(meta && typeof meta === "object" ? { meta: { ...meta } } : {}),
+    };
+    const key = String(name);
+    const list = samples.get(key) || [];
+    list.push(entry);
+    if (list.length > cap) list.splice(0, list.length - cap);
+    samples.set(key, list);
+    return entry;
+  }
+
+  function mark(name) {
+    if (!active() || !name) return null;
+    const value = nowMs(clock);
+    marks.set(String(name), value);
+    return value;
+  }
+
+  function measure(name, startName, endName = null, meta = null) {
+    if (!active() || !name || !startName) return null;
+    const start = marks.get(String(startName));
+    if (!Number.isFinite(start)) return null;
+    const end = endName == null ? nowMs(clock) : marks.get(String(endName));
+    if (!Number.isFinite(end)) return null;
+    return sample(String(name), Math.max(0, end - start), meta);
+  }
+
+  function time(name, meta = null) {
+    if (!active() || !name) return () => null;
+    const started = nowMs(clock);
+    let finished = false;
+    return (extraMeta = null) => {
+      if (finished) return null;
+      finished = true;
+      const mergedMeta = meta || extraMeta
+        ? { ...(meta || {}), ...(extraMeta || {}) }
+        : null;
+      return sample(String(name), Math.max(0, nowMs(clock) - started), mergedMeta);
+    };
+  }
+
+  function reset() {
+    counters.clear();
+    gauges.clear();
+    samples.clear();
+    marks.clear();
+  }
+
+  function snapshot() {
+    const sampleSnapshot = {};
+    for (const [name, list] of samples) sampleSnapshot[name] = list.map((entry) => ({ ...entry }));
+    return {
+      schemaVersion: 1,
+      createdAt: nowMs(wallClock),
+      startedAt,
+      counters: Object.fromEntries(counters),
+      gauges: Object.fromEntries(gauges),
+      samples: sampleSnapshot,
+    };
+  }
+
+  return {
+    increment,
+    gauge,
+    sample,
+    mark,
+    measure,
+    time,
+    reset,
+    snapshot,
+  };
+}
+
+// Shared collector for modules that do not need dependency injection. Tests and
+// sensitive workflows can create isolated collectors via createPerformanceObserver.
+export const perfObserver = createPerformanceObserver();

--- a/src/lib/telemetry-cache.js
+++ b/src/lib/telemetry-cache.js
@@ -1,0 +1,57 @@
+// Small TTL + single-flight cache used by Clash telemetry readers.
+// Values are kept in-memory only and invalidated on runtime generation changes.
+
+export function createTelemetryCache({ clock = () => Date.now() } = {}) {
+  const values = new Map();
+  const inFlight = new Map();
+
+  function now() {
+    const value = Number(clock());
+    return Number.isFinite(value) ? value : Date.now();
+  }
+
+  async function get(key, loader, { ttlMs = 0, force = false } = {}) {
+    const normalizedKey = String(key);
+    const ttl = Math.max(0, Number(ttlMs) || 0);
+    const current = values.get(normalizedKey);
+    const at = now();
+    if (!force && current && at - current.at <= ttl) return current.value;
+
+    const pending = inFlight.get(normalizedKey);
+    if (pending) return pending;
+
+    const task = Promise.resolve()
+      .then(loader)
+      .then((value) => {
+        values.set(normalizedKey, { at: now(), value });
+        return value;
+      })
+      .finally(() => {
+        if (inFlight.get(normalizedKey) === task) inFlight.delete(normalizedKey);
+      });
+    inFlight.set(normalizedKey, task);
+    return task;
+  }
+
+  function invalidate(prefix = null) {
+    if (prefix == null) {
+      values.clear();
+      return;
+    }
+    const normalized = String(prefix);
+    for (const key of values.keys()) {
+      if (key.startsWith(normalized)) values.delete(key);
+    }
+  }
+
+  function peek(key) {
+    return values.get(String(key))?.value;
+  }
+
+  function clear() {
+    values.clear();
+    inFlight.clear();
+  }
+
+  return { get, invalidate, peek, clear };
+}

--- a/src/lib/traffic-meter.js
+++ b/src/lib/traffic-meter.js
@@ -9,8 +9,9 @@
 // по каждому источнику — «использовано за N дней» переживает реконнекты и
 // перезапуски приложения.
 
+import { getTrafficTotal } from "/lib/clash-api.js";
+
 const KEY_PREFIX = "ninety.traffic.";
-const invoke = window.__TAURI__?.core?.invoke;
 
 function load(sourceKey) {
   try {
@@ -61,10 +62,10 @@ async function poll() {
   const runId = meterRunId;
   const key = curKey;
   const token = runtimeToken;
-  if (!invoke || !key) return;
+  if (!key) return;
   if (token && runtimeProvider?.isCurrent && !runtimeProvider.isCurrent(token)) return;
   let t;
-  try { t = await invoke("clash_traffic_total", { port: clashPort }); }
+  try { t = await getTrafficTotal(clashPort, { token }); }
   catch { return; } // ядро ещё не подняло clash-API / уже умерло — пропускаем тик
   if (runId !== meterRunId || key !== curKey || token !== runtimeToken) return;
   if (token && runtimeProvider?.isCurrent && !runtimeProvider.isCurrent(token)) return;

--- a/tests/activity-controller.test.mjs
+++ b/tests/activity-controller.test.mjs
@@ -1,0 +1,67 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createActivityController } from "../src/lib/activity-controller.js";
+
+function eventTarget(extra = {}) {
+  const listeners = new Map();
+  return {
+    ...extra,
+    addEventListener(name, fn) {
+      const set = listeners.get(name) || new Set();
+      set.add(fn);
+      listeners.set(name, set);
+    },
+    removeEventListener(name, fn) { listeners.get(name)?.delete(fn); },
+    emit(name) { for (const fn of [...(listeners.get(name) || [])]) fn(); },
+    count(name) { return listeners.get(name)?.size || 0; },
+  };
+}
+
+test("controller follows visibility, focus and active view", () => {
+  const doc = eventTarget({ visibilityState: "visible", hasFocus: () => true });
+  const win = eventTarget();
+  const controller = createActivityController({ document: doc, window: win });
+  const states = [];
+  controller.subscribe((state) => states.push({ ...state }));
+  controller.mount();
+
+  assert.equal(controller.isInteractive("home"), true);
+  controller.setView("logs");
+  assert.equal(controller.isInteractive("home"), false);
+  assert.equal(controller.isInteractive("logs"), true);
+
+  doc.visibilityState = "hidden";
+  doc.emit("visibilitychange");
+  assert.equal(controller.isVisible(), false);
+  assert.equal(controller.isInteractive("logs"), false);
+
+  doc.visibilityState = "visible";
+  doc.emit("visibilitychange");
+  win.emit("blur");
+  assert.equal(controller.isFocused(), false);
+  win.emit("focus");
+  assert.equal(controller.isInteractive("logs"), true);
+  assert.ok(states.length >= 5);
+
+  controller.destroy();
+  assert.equal(doc.count("visibilitychange"), 0);
+  assert.equal(win.count("focus"), 0);
+  assert.equal(win.count("blur"), 0);
+});
+
+test("mount and no-op state updates are idempotent", () => {
+  const doc = eventTarget({ visibilityState: "visible", hasFocus: () => true });
+  const win = eventTarget();
+  const controller = createActivityController({ document: doc, window: win });
+  let notifications = 0;
+  controller.subscribe(() => notifications++);
+  controller.mount();
+  controller.mount();
+  controller.setView("home");
+  doc.emit("visibilitychange");
+
+  assert.equal(doc.count("visibilitychange"), 1);
+  assert.equal(win.count("focus"), 1);
+  assert.equal(notifications, 2); // immediate subscribe + initial mount snapshot
+});

--- a/tests/distinct-emitter.test.mjs
+++ b/tests/distinct-emitter.test.mjs
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createDistinctEmitter } from "../src/lib/distinct-emitter.js";
+
+test("distinct emitter suppresses equivalent payloads", () => {
+  const values = [];
+  const emit = createDistinctEmitter((value) => values.push(value));
+
+  assert.equal(emit({ delay: 30, nodeTag: "a" }), true);
+  assert.equal(emit({ delay: 30, nodeTag: "a" }), false);
+  assert.equal(emit({ delay: 31, nodeTag: "a" }), true);
+  assert.equal(values.length, 2);
+});
+
+test("reset makes current payload observable again", () => {
+  let calls = 0;
+  const emit = createDistinctEmitter(() => calls++, (value) => value.id);
+  emit({ id: 1 });
+  emit({ id: 1 });
+  emit.reset();
+  emit({ id: 1 });
+  assert.equal(calls, 2);
+});

--- a/tests/performance-observer.test.mjs
+++ b/tests/performance-observer.test.mjs
@@ -1,0 +1,63 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createPerformanceObserver } from "../src/lib/performance-observer.js";
+
+test("collector tracks counters, gauges and bounded samples", () => {
+  let wall = 1000;
+  const observer = createPerformanceObserver({
+    sampleCap: 2,
+    clock: () => 50,
+    wallClock: () => wall++,
+  });
+
+  assert.equal(observer.increment("ipc.calls"), 1);
+  assert.equal(observer.increment("ipc.calls", 2), 3);
+  assert.equal(observer.gauge("window.visible", true), 1);
+  observer.sample("render.ms", 1);
+  observer.sample("render.ms", 2);
+  observer.sample("render.ms", 3, { view: "home" });
+
+  const snapshot = observer.snapshot();
+  assert.equal(snapshot.schemaVersion, 1);
+  assert.equal(snapshot.counters["ipc.calls"], 3);
+  assert.equal(snapshot.gauges["window.visible"], 1);
+  assert.deepEqual(snapshot.samples["render.ms"].map((x) => x.value), [2, 3]);
+  assert.deepEqual(snapshot.samples["render.ms"][1].meta, { view: "home" });
+});
+
+test("marks and one-shot timers record durations", () => {
+  let monotonic = 10;
+  const observer = createPerformanceObserver({
+    clock: () => monotonic,
+    wallClock: () => 500,
+  });
+
+  observer.mark("startup.begin");
+  monotonic = 25;
+  observer.mark("startup.ready");
+  observer.measure("startup.ms", "startup.begin", "startup.ready");
+
+  monotonic = 40;
+  const finish = observer.time("ipc.ms", { command: "health_snapshot" });
+  monotonic = 46;
+  finish();
+  monotonic = 99;
+  assert.equal(finish(), null);
+
+  const snapshot = observer.snapshot();
+  assert.equal(snapshot.samples["startup.ms"][0].value, 15);
+  assert.equal(snapshot.samples["ipc.ms"][0].value, 6);
+  assert.deepEqual(snapshot.samples["ipc.ms"][0].meta, { command: "health_snapshot" });
+});
+
+test("disabled collector is a no-op", () => {
+  const observer = createPerformanceObserver({ enabled: false });
+  observer.increment("x");
+  observer.gauge("y", 1);
+  observer.sample("z", 1);
+  observer.mark("a");
+  assert.deepEqual(observer.snapshot().counters, {});
+  assert.deepEqual(observer.snapshot().gauges, {});
+  assert.deepEqual(observer.snapshot().samples, {});
+});

--- a/tests/telemetry-cache.test.mjs
+++ b/tests/telemetry-cache.test.mjs
@@ -1,0 +1,46 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createTelemetryCache } from "../src/lib/telemetry-cache.js";
+
+test("cache reuses fresh values and expires by TTL", async () => {
+  let now = 100;
+  let calls = 0;
+  const cache = createTelemetryCache({ clock: () => now });
+  const load = async () => ++calls;
+
+  assert.equal(await cache.get("proxies:9090", load, { ttlMs: 1000 }), 1);
+  assert.equal(await cache.get("proxies:9090", load, { ttlMs: 1000 }), 1);
+  assert.equal(calls, 1);
+
+  now = 1200;
+  assert.equal(await cache.get("proxies:9090", load, { ttlMs: 1000 }), 2);
+  assert.equal(calls, 2);
+});
+
+test("concurrent requests join one loader", async () => {
+  let release;
+  let calls = 0;
+  const cache = createTelemetryCache();
+  const loader = () => {
+    calls++;
+    return new Promise((resolve) => { release = resolve; });
+  };
+
+  const a = cache.get("connections", loader, { ttlMs: 0 });
+  const b = cache.get("connections", loader, { ttlMs: 0, force: true });
+  await Promise.resolve();
+  assert.equal(calls, 1);
+  release([1, 2, 3]);
+  assert.deepEqual(await a, [1, 2, 3]);
+  assert.deepEqual(await b, [1, 2, 3]);
+});
+
+test("prefix invalidation only removes matching telemetry", async () => {
+  const cache = createTelemetryCache();
+  await cache.get("proxies:9090", async () => "p", { ttlMs: 1000 });
+  await cache.get("connections:9090", async () => "c", { ttlMs: 1000 });
+  cache.invalidate("proxies:");
+  assert.equal(cache.peek("proxies:9090"), undefined);
+  assert.equal(cache.peek("connections:9090"), "c");
+});


### PR DESCRIPTION
## Что сделано
- log tail парсится один раз только при изменении файла;
- search/level filters работают по кэшированным structured entries;
- одинаковый HTML не устанавливается повторно;
- search input получил debounce 120 мс;
- auto-refresh останавливается в трее и немедленно возобновляется при возврате;
- добавлены timings/counters для read/render/suppressed renders.

## Эффект
Убраны повторные split/regex/HTML parse циклы по 800 строкам и двухсекундные чтения хвоста, когда окно скрыто.

## Проверка
- `npm test`
- `npm run lint`
- ручная проверка источников sing-box/xray/naive/trusttunnel/DPI, search и level filter.

Стек PR: 5/7. Base: PR #69.