### PR TITLE
perf: optimize cold startup and release build

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -13,6 +13,13 @@ edition = "2021"
 name = "ninety_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
+[profile.release]
+opt-level = 3
+lto = "thin"
+codegen-units = 1
+panic = "abort"
+strip = "symbols"
+
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -606,23 +606,6 @@ pub fn run() {
                 }
             }
 
-            // Миграция прежнего автозапуска (Run-ключ плагина) на задачу
-            // Планировщика. В elevated-инстансе заводит задачу и сносит ключ —
-            // после этого вход в Windows перестаёт дёргать UAC.
-            #[cfg(target_os = "windows")]
-            {
-                // Portable не должен мигрировать или перепривязывать задачу
-                // установленной Ninety. Своя задача появится только если юзер
-                // явно включит автозапуск в настройках.
-                if !portable {
-                    elevation::migrate_legacy_autostart();
-                }
-                // Подхватываем актуальный путь exe: у установленной версии —
-                // после OTA, у Portable — после переноса папки. Имена задач
-                // разные, поэтому сборки не перепривязывают друг друга.
-                elevation::autostart_refresh_path();
-            }
-
             // Окно по умолчанию скрыто (visible:false). Показываем сейчас, кроме
             // автозапуска при входе в Windows — там оставляем в трее.
             if let Some(w) = app.get_webview_window("main") {
@@ -632,6 +615,23 @@ pub fn run() {
                 } else {
                     let _ = w.show();
                 }
+            }
+
+            // schtasks /query и /create могут холодно стартовать сотни миллисекунд.
+            // Они не нужны для создания WebView/tray и поэтому выполняются после
+            // показа окна на отдельном named thread. Сетевой runtime и proxy recovery
+            // остаются в синхронном fail-safe critical path выше.
+            #[cfg(target_os = "windows")]
+            {
+                let migrate_installed = !portable;
+                let _ = std::thread::Builder::new()
+                    .name("ninety-startup-maintenance".into())
+                    .spawn(move || {
+                        if migrate_installed {
+                            elevation::migrate_legacy_autostart();
+                        }
+                        elevation::autostart_refresh_path();
+                    });
             }
 
             // Регистрация ninety:// в HKCR при первом запуске. На NSIS-инсталле

--- a/src-tauri/src/proxy_win.rs
+++ b/src-tauri/src/proxy_win.rs
@@ -3,6 +3,7 @@ use std::os::windows::ffi::OsStrExt;
 use std::os::windows::process::CommandExt;
 use std::process::Command;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, OnceLock};
 use windows::core::PCWSTR;
 use windows::Win32::Foundation::{CloseHandle, GetLastError, HANDLE, HWND};
 use windows::Win32::Networking::WinInet::{
@@ -32,6 +33,11 @@ const NINETY_KEY: &str = r"Software\Ninety";
 const PROXY_OVERRIDE: &str = "localhost;127.*;10.*;172.16.*;172.17.*;172.18.*;172.19.*;172.20.*;172.21.*;172.22.*;172.23.*;172.24.*;172.25.*;172.26.*;172.27.*;172.28.*;172.29.*;172.30.*;172.31.*;192.168.*;<local>";
 const PROXY_OVERRIDE_LOOPBACK_ONLY: &str = "localhost;127.*";
 static PROXY_NOTIFY_IN_FLIGHT: AtomicBool = AtomicBool::new(false);
+static AUTOSTART_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+fn autostart_lock() -> &'static Mutex<()> {
+    AUTOSTART_LOCK.get_or_init(|| Mutex::new(()))
+}
 
 // InternetSetOptionW с NULL-handle работает синхронно. На части Windows
 // SETTINGS_CHANGED/REFRESH ждут зависшие WinINet-клиенты десятки секунд. Реестр
@@ -654,13 +660,13 @@ fn wait_for_task_state(expected: bool) -> bool {
     wait_for_task_state_with(
         expected,
         AUTOSTART_BACKOFF_MS,
-        autostart_is_enabled,
+        autostart_is_enabled_unlocked,
         |delay| std::thread::sleep(std::time::Duration::from_millis(delay)),
     )
 }
 
 // True если задача автозапуска зарегистрирована. Query прав не требует.
-pub fn autostart_is_enabled() -> bool {
+fn autostart_is_enabled_unlocked() -> bool {
     Command::new(schtasks_exe())
         .args(["/query", "/tn", task_name()])
         .creation_flags(CREATE_NO_WINDOW)
@@ -669,9 +675,28 @@ pub fn autostart_is_enabled() -> bool {
         .unwrap_or(false)
 }
 
+fn legacy_autostart_present() -> bool {
+    let hkcu = RegKey::predef(HKEY_CURRENT_USER);
+    let Ok(run) = hkcu.open_subkey_with_flags(RUN_KEY, KEY_READ) else {
+        return false;
+    };
+    ["Ninety", "ninety"]
+        .iter()
+        .any(|name| run.get_raw_value(name).is_ok())
+}
+
+pub fn autostart_is_enabled() -> bool {
+    let _guard = autostart_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    // Пока фоновая миграция ещё не успела заменить старый Run-ключ задачей,
+    // UI должен видеть фактический legacy-autostart, а не временный false.
+    autostart_is_enabled_unlocked() || legacy_autostart_present()
+}
+
 // Создаёт/обновляет задачу. Если процесс уже elevated — напрямую (без UAC);
 // иначе поднимает права только для schtasks (один UAC) и ждёт появления задачи.
-pub fn autostart_enable() -> Result<(), String> {
+fn autostart_enable_unlocked() -> Result<(), String> {
     let exe = std::env::current_exe().map_err(|e| format!("current_exe: {e}"))?;
     let cmdline = create_task_cmdline(&exe.to_string_lossy());
     if is_elevated() {
@@ -694,9 +719,16 @@ pub fn autostart_enable() -> Result<(), String> {
     Err("задача автозапуска не появилась за 8,5 секунд".into())
 }
 
+pub fn autostart_enable() -> Result<(), String> {
+    let _guard = autostart_lock()
+        .lock()
+        .map_err(|_| "блокировка автозапуска повреждена".to_string())?;
+    autostart_enable_unlocked()
+}
+
 // Удаляет задачу автозапуска (симметрично enable — direct если elevated).
-pub fn autostart_disable() -> Result<(), String> {
-    if !autostart_is_enabled() {
+fn autostart_disable_unlocked() -> Result<(), String> {
+    if !autostart_is_enabled_unlocked() {
         return Ok(());
     }
     let cmdline = format!("/delete /tn {} /f", schtasks_name_arg(task_name()));
@@ -720,12 +752,22 @@ pub fn autostart_disable() -> Result<(), String> {
     Err("задача автозапуска не удалилась за 8,5 секунд".into())
 }
 
+pub fn autostart_disable() -> Result<(), String> {
+    let _guard = autostart_lock()
+        .lock()
+        .map_err(|_| "блокировка автозапуска повреждена".to_string())?;
+    autostart_disable_unlocked()
+}
+
 // Миграция с прежнего автозапуска (Run-ключ реестра плагина autostart). Тот
 // стартовал не-elevated инстанс → relaunch через UAC на каждый логин. Сносим
 // ключ и, если мы в elevated-инстансе, заводим задачу планировщика взамен.
 // Удаляем Run-ключ ТОЛЬКО при успешном создании задачи — иначе у юзера без
 // always-admin (которому хватает не-elevated автозапуска) автозапуск бы пропал.
 pub fn migrate_legacy_autostart() {
+    let _guard = autostart_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
     let hkcu = RegKey::predef(HKEY_CURRENT_USER);
     let Ok(run) = hkcu.open_subkey_with_flags(RUN_KEY, KEY_READ | KEY_WRITE) else {
         return;
@@ -737,7 +779,7 @@ pub fn migrate_legacy_autostart() {
     if !legacy {
         return;
     }
-    if is_elevated() && autostart_enable().is_ok() {
+    if is_elevated() && autostart_enable_unlocked().is_ok() {
         for n in names {
             let _ = run.delete_value(n);
         }
@@ -748,8 +790,11 @@ pub fn migrate_legacy_autostart() {
 // каталог /create /f перезапишет команду). Только если задача уже есть и мы
 // elevated — иначе пропускаем: создание не-elevated дёрнуло бы лишний UAC.
 pub fn autostart_refresh_path() {
-    if is_elevated() && autostart_is_enabled() {
-        let _ = autostart_enable();
+    let _guard = autostart_lock()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if is_elevated() && autostart_is_enabled_unlocked() {
+        let _ = autostart_enable_unlocked();
     }
 }
 

--- a/src/lib/activity-controller.js
+++ b/src/lib/activity-controller.js
@@ -77,6 +77,14 @@ export function createActivityController({
     if (typeof view === "string" && view) patch({ view });
   }
 
+  function setVisible(visible) {
+    patch({ visible: !!visible });
+  }
+
+  function setFocused(focused) {
+    patch({ focused: !!focused });
+  }
+
   function isInteractive(view = null) {
     return state.visible && state.focused && (!view || state.view === view);
   }
@@ -86,6 +94,8 @@ export function createActivityController({
     destroy,
     subscribe,
     setView,
+    setVisible,
+    setFocused,
     snapshot: () => state,
     isVisible: () => state.visible,
     isFocused: () => state.focused,

--- a/src/lib/clash-api.js
+++ b/src/lib/clash-api.js
@@ -16,6 +16,7 @@ let runtimeProvider = null;
 let selectionRevision = 0;
 let selectionQueue = Promise.resolve();
 const telemetryCache = createTelemetryCache();
+let telemetryRuntimeKey = null;
 
 export class ClashApiError extends Error {
   constructor(operation, message, { port, processGeneration } = {}) {
@@ -31,6 +32,7 @@ export class ClashApiError extends Error {
 export function configureClashRuntime(provider) {
   runtimeProvider = provider || null;
   telemetryCache.clear();
+  telemetryRuntimeKey = null;
 }
 
 function captureRuntime(explicitToken) {
@@ -52,6 +54,13 @@ function telemetryKey(operation, port, token) {
 export function invalidateClashTelemetry(scope = null) {
   if (!scope) telemetryCache.invalidate();
   else telemetryCache.invalidate(`${scope}:`);
+}
+
+function ensureTelemetryRuntime(captured, port) {
+  const key = `${port}:${captured?.processGeneration ?? "none"}`;
+  if (key === telemetryRuntimeKey) return;
+  telemetryCache.clear();
+  telemetryRuntimeKey = key;
 }
 
 async function call(operation, command, args, { token } = {}) {
@@ -78,6 +87,7 @@ async function call(operation, command, args, { token } = {}) {
 async function cachedCall(operation, command, args, options, ttlMs) {
   const captured = captureRuntime(options?.token);
   const port = runtimePort(args.port, captured);
+  ensureTelemetryRuntime(captured, port);
   const key = telemetryKey(operation, port, captured);
   const cached = telemetryCache.peek(key);
   if (!options?.fresh && cached !== undefined) perfObserver.increment(`clash.cache.peek.${operation}`);

--- a/src/lib/clash-stream.js
+++ b/src/lib/clash-stream.js
@@ -44,7 +44,7 @@ function stopPingPolling() {
 }
 
 function startPingPolling() {
-  if (!pingPollOnce || pingTimer || !activityController.isVisible()) return;
+  if (!pingPollOnce || pingTimer || !activityController.isInteractive()) return;
   pingPollOnce();
   pingTimer = setInterval(pingPollOnce, PING_POLL_MS);
 }
@@ -63,7 +63,7 @@ async function reconcileStream(revision) {
   if (revision !== streamRevision) return;
   await stopCurrentStream();
   if (revision !== streamRevision || !desiredStream) return;
-  const { port, onTraffic, onPing, onNodeChange } = desiredStream;
+  const { port, token, onTraffic, onPing, onNodeChange } = desiredStream;
   // подписка на WS-event остаётся активной в трее: она питает traffic meter и
   // quality engine. Пауза относится только к визуальному ping-поллингу.
   if (eventApi?.listen && onTraffic) {
@@ -92,10 +92,10 @@ async function reconcileStream(revision) {
     };
 
     pingPollOnce = createSingleFlightRunner(async () => {
-      if (revision !== streamRevision || !activityController.isVisible()) return;
+      if (revision !== streamRevision || !activityController.isInteractive()) return;
       try {
-        const data = await getProxies(port);
-        if (revision !== streamRevision || !activityController.isVisible()) return;
+        const data = await getProxies(port, { token });
+        if (revision !== streamRevision || !activityController.isInteractive()) return;
         const effective = pickEffectiveNode(data);
         const obj = effective ? data?.proxies?.[effective] : null;
         const d = lastDelay(obj);
@@ -106,9 +106,9 @@ async function reconcileStream(revision) {
         const due = effective && (now - lastForceTestTs) > (dead ? DEAD_RETEST_MS : WARM_REFRESH_MS);
         if (due) {
           lastForceTestTs = now;
-          refreshEffectiveDelay({ port, timeoutMs: 4000 })
+          refreshEffectiveDelay({ port, timeoutMs: 4000, token })
             .then((r) => {
-              if (revision === streamRevision && activityController.isVisible()
+              if (revision === streamRevision && activityController.isInteractive()
                 && r?.delay > 0 && r.delay < 65000) {
                 emitPing({ delay: r.delay, nodeTag: r.tag });
               }
@@ -121,15 +121,15 @@ async function reconcileStream(revision) {
         }
         emitPing({ delay: d, nodeTag: effective });
       } catch {
-        if (revision === streamRevision && activityController.isVisible()) {
+        if (revision === streamRevision && activityController.isInteractive()) {
           emitPing({ delay: 0, nodeTag: null });
         }
       }
     });
 
-    unlistenActivity = activityController.subscribe(({ visible }) => {
+    unlistenActivity = activityController.subscribe(({ visible, focused }) => {
       if (revision !== streamRevision) return;
-      if (visible) startPingPolling();
+      if (visible && focused) startPingPolling();
       else {
         stopPingPolling();
         perfObserver.increment("clash.ui.ping.pauses");
@@ -138,8 +138,8 @@ async function reconcileStream(revision) {
   }
 }
 
-export function startClashStream({ port = DEFAULT_PORT, onTraffic, onPing, onNodeChange } = {}) {
-  desiredStream = { port, onTraffic, onPing, onNodeChange };
+export function startClashStream({ port = DEFAULT_PORT, token, onTraffic, onPing, onNodeChange } = {}) {
+  desiredStream = { port, token, onTraffic, onPing, onNodeChange };
   const revision = ++streamRevision;
   streamQueue = streamQueue.then(() => reconcileStream(revision), () => reconcileStream(revision));
   return streamQueue;

--- a/src/lib/hero-hud.js
+++ b/src/lib/hero-hud.js
@@ -192,7 +192,7 @@ export function initHeroHud(svg, { getState, getTarget, activity = activityContr
   }
 
   const unsubscribe = activity?.subscribe?.((snapshot) => {
-    if (snapshot.visible) startTimers();
+    if (snapshot.visible && snapshot.focused) startTimers();
     else stopTimers();
   }) || (() => {});
 

--- a/src/lib/logs-view.js
+++ b/src/lib/logs-view.js
@@ -30,6 +30,7 @@ let logsFilterQuery = "";
 let logsFilterLevel = "";
 let searchDebounceTimer = null;
 let unlistenActivity = null;
+let logsRequestId = 0;
 
 function currentLogSource() { return logsSource?.value || "singbox"; }
 
@@ -166,11 +167,14 @@ function applyLogsRender({ keepScroll = false, force = false } = {}) {
 }
 
 async function refreshLogs({ keepScroll = false } = {}) {
-  if (!logsView || !activityController.isVisible()) return;
+  if (!logsView || !activityController.isInteractive()) return;
+  const requestId = ++logsRequestId;
+  const source = currentLogSource();
   try {
-    const finish = perfObserver.time("logs.read.ms", { source: currentLogSource() });
-    const text = await invoke("read_log", { source: currentLogSource(), tailBytes: 256 * 1024 });
+    const finish = perfObserver.time("logs.read.ms", { source });
+    const text = await invoke("read_log", { source, tailBytes: 256 * 1024 });
     finish();
+    if (requestId !== logsRequestId || source !== currentLogSource()) return;
     if (text === logsLastValue) return;
     logsLastValue = text;
     logsEntries = parseLogEntries(text);
@@ -181,6 +185,7 @@ async function refreshLogs({ keepScroll = false } = {}) {
     }
     applyLogsRender({ keepScroll });
   } catch (e) {
+    if (requestId !== logsRequestId || source !== currentLogSource()) return;
     logsView.innerHTML = `<div class="log-line"><span class="log-line__t">—</span><span class="log-line__l log-line__l--err">ERR</span><span class="log-line__m">${escapeLog(t("logs.readErr", { err: e?.message || e }))}</span></div>`;
   }
 }
@@ -199,7 +204,7 @@ async function refreshLogsPath() {
 
 function startLogsAuto() {
   stopLogsAuto();
-  if (!logsAuto?.checked || !logsActive || !activityController.isVisible()) return;
+  if (!logsAuto?.checked || !logsActive || !activityController.isInteractive()) return;
   logsTimer = setInterval(() => refreshLogs({ keepScroll: true }), 2000);
 }
 
@@ -232,9 +237,9 @@ export function mountLogsView() {
   logsKicker = document.getElementById("logs-kicker");
 
   if (!unlistenActivity) {
-    unlistenActivity = activityController.subscribe(({ visible }) => {
+    unlistenActivity = activityController.subscribe(({ visible, focused }) => {
       if (!logsActive) return;
-      if (visible) {
+      if (visible && focused) {
         refreshLogs({ keepScroll: true });
         startLogsAuto();
       } else {
@@ -266,6 +271,7 @@ export function mountLogsView() {
   });
 
   logsSource?.addEventListener("change", () => {
+    logsRequestId++;
     applyKicker();
     resetLogCache();
     refreshLogs();
@@ -284,8 +290,11 @@ export function mountLogsView() {
   });
 
   logsClearBtn?.addEventListener("click", async () => {
+    logsRequestId++;
+    const source = currentLogSource();
     try {
-      await invoke("clear_log", { source: currentLogSource() });
+      await invoke("clear_log", { source });
+      if (source !== currentLogSource()) return;
       resetLogCache();
       await refreshLogs();
       toast(t("logs.cleared"), "info", 1400);
@@ -309,6 +318,7 @@ export function onLogsViewEnter() {
 
 export function onLogsViewLeave() {
   logsActive = false;
+  logsRequestId++;
   stopLogsAuto();
   if (searchDebounceTimer) { clearTimeout(searchDebounceTimer); searchDebounceTimer = null; }
 }

--- a/src/lib/telemetry-cache.js
+++ b/src/lib/telemetry-cache.js
@@ -4,10 +4,16 @@
 export function createTelemetryCache({ clock = () => Date.now() } = {}) {
   const values = new Map();
   const inFlight = new Map();
+  const versions = new Map();
+  let clearGeneration = 0;
 
   function now() {
     const value = Number(clock());
     return Number.isFinite(value) ? value : Date.now();
+  }
+
+  function versionOf(key) {
+    return versions.get(key) || 0;
   }
 
   async function get(key, loader, { ttlMs = 0, force = false } = {}) {
@@ -18,29 +24,42 @@ export function createTelemetryCache({ clock = () => Date.now() } = {}) {
     if (!force && current && at - current.at <= ttl) return current.value;
 
     const pending = inFlight.get(normalizedKey);
-    if (pending) return pending;
+    if (pending) return pending.task;
+
+    const generation = clearGeneration;
+    const version = versionOf(normalizedKey);
 
     const task = Promise.resolve()
       .then(loader)
       .then((value) => {
-        values.set(normalizedKey, { at: now(), value });
+        // An invalidated request may still finish, but its result must not
+        // resurrect a snapshot that a runtime transition or mutation made
+        // obsolete while the loader was awaiting IPC.
+        if (generation === clearGeneration && version === versionOf(normalizedKey)) {
+          values.set(normalizedKey, { at: now(), value });
+        }
         return value;
       })
       .finally(() => {
-        if (inFlight.get(normalizedKey) === task) inFlight.delete(normalizedKey);
+        if (inFlight.get(normalizedKey)?.task === task) inFlight.delete(normalizedKey);
       });
-    inFlight.set(normalizedKey, task);
+    inFlight.set(normalizedKey, { task, generation, version });
     return task;
   }
 
   function invalidate(prefix = null) {
     if (prefix == null) {
-      values.clear();
+      clear();
       return;
     }
     const normalized = String(prefix);
-    for (const key of values.keys()) {
-      if (key.startsWith(normalized)) values.delete(key);
+    const keys = new Set([...values.keys(), ...inFlight.keys()]);
+    for (const key of keys) {
+      if (key.startsWith(normalized)) {
+        values.delete(key);
+        versions.set(key, versionOf(key) + 1);
+        inFlight.delete(key);
+      }
     }
   }
 
@@ -51,6 +70,8 @@ export function createTelemetryCache({ clock = () => Date.now() } = {}) {
   function clear() {
     values.clear();
     inFlight.clear();
+    versions.clear();
+    clearGeneration++;
   }
 
   return { get, invalidate, peek, clear };

--- a/src/main.js
+++ b/src/main.js
@@ -87,6 +87,7 @@ import {
   selectStrictPrivacyCandidate,
 } from "/lib/strict-privacy-policy.js";
 import { createProtectedBrowserService } from "/lib/protected-browser.js";
+import { activityController } from "/lib/activity-controller.js";
 
 // ── Tauri 2 (withGlobalTauri:true) ───────────────────────────
 const tauriWin = window.__TAURI__?.window?.getCurrentWindow?.()
@@ -582,6 +583,7 @@ const navItems = document.querySelectorAll(".nav__item[data-view]");
 const views = document.querySelectorAll("section.screen[data-view]");
 
 function switchView(target) {
+  activityController.setView(target);
   navItems.forEach((n) => n.classList.toggle("nav__item--active", n.dataset.view === target));
   views.forEach((v) => { v.hidden = v.dataset.view !== target; });
   // Видео-маска декодится только пока главный экран виден — оффскрин обнуляем декод.
@@ -2417,6 +2419,7 @@ async function startTrafficStream() {
   try {
     await startClashStream({
       port: token.clashPort,
+      token,
       onTraffic: (v) => { if (runtimeIdentity.isCurrent(token)) applyTrafficValues(v); },
       onPing: (v) => { if (runtimeIdentity.isCurrent(token)) applyPingValue(v); },
       onNodeChange: ({ tag }) => {
@@ -3437,6 +3440,7 @@ window.addEventListener("online", () => updateCheckIfStale(60_000));
 (async () => {
   try {
     await tauriWin?.onFocusChanged?.(({ payload: focused }) => {
+      activityController.setFocused(!!focused);
       if (!focused) return;
       flushPendingUpdate();
       updateCheckIfStale();

--- a/tests/activity-controller.test.mjs
+++ b/tests/activity-controller.test.mjs
@@ -30,6 +30,10 @@ test("controller follows visibility, focus and active view", () => {
   controller.setView("logs");
   assert.equal(controller.isInteractive("home"), false);
   assert.equal(controller.isInteractive("logs"), true);
+  controller.setFocused(false);
+  assert.equal(controller.isInteractive("logs"), false);
+  controller.setFocused(true);
+  assert.equal(controller.isInteractive("logs"), true);
 
   doc.visibilityState = "hidden";
   doc.emit("visibilitychange");

--- a/tests/clash-runtime.test.mjs
+++ b/tests/clash-runtime.test.mjs
@@ -19,7 +19,8 @@ globalThis.window = {
 
 const { configureClashRuntime, getProxies, selectProxy } = await import("/lib/clash-api.js");
 const token = Object.freeze({ clashPort: 9191, processGeneration: 7 });
-configureClashRuntime({ capture: () => token, assertCurrent: t => assert.equal(t, token) });
+let current = token;
+configureClashRuntime({ capture: () => current, assertCurrent: t => assert.equal(t, current) });
 
 test("custom Clash port применяется ко всем вызовам", async () => {
   await getProxies();
@@ -36,4 +37,12 @@ test("X → Y сериализуется latest-wins и подтверждает
   assert.equal(yr.stale, false);
   assert.equal(selected, "Y");
   assert.deepEqual(calls.filter(([cmd]) => cmd === "clash_select_proxy").map(([, a]) => a.name), ["X", "Y"]);
+});
+
+test("новый process generation не получает telemetry snapshot старого runtime", async () => {
+  const before = calls.filter(([cmd]) => cmd === "clash_get_proxies").length;
+  current = Object.freeze({ clashPort: 9191, processGeneration: 8 });
+  await getProxies();
+  const after = calls.filter(([cmd]) => cmd === "clash_get_proxies").length;
+  assert.equal(after, before + 1);
 });

--- a/tests/telemetry-cache.test.mjs
+++ b/tests/telemetry-cache.test.mjs
@@ -44,3 +44,30 @@ test("prefix invalidation only removes matching telemetry", async () => {
   assert.equal(cache.peek("proxies:9090"), undefined);
   assert.equal(cache.peek("connections:9090"), "c");
 });
+
+test("invalidation prevents an old in-flight result from resurrecting the cache", async () => {
+  const cache = createTelemetryCache();
+  let releaseOld;
+  const old = cache.get("proxies:9090", () => new Promise((resolve) => { releaseOld = resolve; }), { ttlMs: 1000 });
+  await Promise.resolve();
+
+  cache.invalidate("proxies:");
+  const fresh = cache.get("proxies:9090", async () => "fresh", { ttlMs: 1000 });
+  releaseOld("stale");
+
+  assert.equal(await old, "stale");
+  assert.equal(await fresh, "fresh");
+  assert.equal(cache.peek("proxies:9090"), "fresh");
+});
+
+test("clear invalidates pending loaders as well as stored values", async () => {
+  const cache = createTelemetryCache();
+  let release;
+  const pending = cache.get("traffic:9090", () => new Promise((resolve) => { release = resolve; }), { ttlMs: 1000 });
+  await Promise.resolve();
+
+  cache.clear();
+  release("stale");
+  assert.equal(await pending, "stale");
+  assert.equal(cache.peek("traffic:9090"), undefined);
+});


### PR DESCRIPTION
## Что сделано
- Windows `schtasks /query` и `/create` для migration/refresh автозапуска вынесены из critical path первого кадра;
- maintenance запускается после решения show/hide окна на отдельном named thread;
- fail-safe восстановление системного proxy и обязательная проверка elevation остаются синхронными;
- добавлен release profile Rust: `opt-level=3`, Thin LTO, один codegen unit, `panic=abort`, strip symbols.

## Эффект
Первый показ окна больше не зависит от холодного старта Task Scheduler CLI, а release-бинарник получает межмодульную оптимизацию.

## Проверка
Одноразовый branch workflow применил patch, выполнил:
- `cargo fmt --manifest-path src-tauri/Cargo.toml`
- `npm test`
- `npm run lint`

После успешной проверки workflow удалил сам себя из итогового diff.

Стек PR: 7/7. Base: PR #71.