### PR TITLE
Add dataplane resilience watchdog

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,6 +33,7 @@ The backend lives under `src-tauri/src/`. It exposes Tauri commands and events f
 The backend is responsible for:
 
 - starting and stopping local engine processes;
+- native dataplane health checks and host-pressure classification;
 - Windows system proxy changes;
 - TUN elevation and autostart behavior;
 - WARP/WireGuard state;
@@ -72,5 +73,21 @@ This keeps the repository smaller and makes release inputs explicit in CI:
 - place binaries where Tauri expects sidecars;
 - build and sign Windows artifacts;
 - generate and publish `latest.json`.
+
+## Runtime health and recovery
+
+`connected` is a UI state, while the native runtime health is tracked separately.
+The Rust backend monitors the actual proxy/TUN datapath through the local
+`probe-in`/mixed inbound, in addition to process liveness. It reports bounded
+states such as `unknown`, `healthy`, `suspect`, `pressure` and `failed`, with a
+runtime generation and a non-sensitive reason code.
+
+When the host is under CPU or memory pressure, Ninety pauses background quality
+remediation instead of switching nodes blindly. A confirmed dataplane failure
+uses a bounded recovery policy: validate an alternative node, switch to it when
+the dataplane probe succeeds, or use the existing controlled runtime reconnect.
+The frontend remains the recovery coordinator for now because it owns the
+profile/config selection; a future Windows service can move that ownership out
+of the WebView.
 
 For the release ritual, see [RELEASING.md](../RELEASING.md).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -78,16 +78,58 @@ This keeps the repository smaller and makes release inputs explicit in CI:
 
 `connected` is a UI state, while the native runtime health is tracked separately.
 The Rust backend monitors the actual proxy/TUN datapath through the local
-`probe-in`/mixed inbound, in addition to process liveness. It reports bounded
-states such as `unknown`, `healthy`, `suspect`, `pressure` and `failed`, with a
-runtime generation and a non-sensitive reason code.
+`probe-in`/mixed inbound, in addition to process liveness and the local Clash
+control API. Liveness has its own fixed HTTPS policy (two independent
+allowlisted endpoints, 16 KiB sample, 6 s total budget and 2.5 s inactivity
+window); it never reuses the quality engine's 64 KiB/800 ms shaping thresholds.
 
-When the host is under CPU or memory pressure, Ninety pauses background quality
-remediation instead of switching nodes blindly. A confirmed dataplane failure
-uses a bounded recovery policy: validate an alternative node, switch to it when
-the dataplane probe succeeds, or use the existing controlled runtime reconnect.
-The frontend remains the recovery coordinator for now because it owns the
-profile/config selection; a future Windows service can move that ownership out
-of the WebView.
+The dataplane decision is a bounded rolling window of three observations:
+
+```text
+new generation → unknown
+two successes in the window → healthy
+two failures in the window → failed
+otherwise → suspect
+```
+
+Therefore `F,S,F` is failed, while `S,S` is healthy. A stale monitor cannot
+write a newer process generation. Host pressure is a separate hysteretic signal
+based on physical/commit memory and scheduler heartbeat lateness. It changes
+the polling interval and pauses quality remediation, but it never clears a
+dataplane failure or authorizes mass node switching.
+
+The native monitor has the following lifecycle states:
+
+```text
+inactive → unknown → suspect → healthy
+                    └──────→ failed → recovering → unknown (new generation)
+                                      └──────────→ cooldown/pressure_wait
+                                      └──────────→ terminal or cleanup_error
+```
+
+Recovery is owned by one native controller. It retains the in-memory launch
+specification, performs a controlled same-config dependency restart, verifies
+processes, Clash, the real dataplane, system-proxy ownership and (when
+required) the WFP barrier, then publishes a new generation. It does not ask
+WebView2 to rebuild a profile or silently select a different server. The
+attempt budget is three per fifteen minutes with a sixty-second cooldown;
+cooldown is retryable and is not terminal. Terminal state is published only
+after fail-closed cleanup is confirmed. A failed cleanup remains
+`cleanup_error`, preserves the kill switch barrier and is retried only within a
+bounded budget.
+
+Strict privacy never silently disables health. It switches to explicit
+`unmonitoredPrivacyMode`/`privacy_passive`: only native process, sidecar, local
+Clash and host-pressure evidence is used, and no direct external probe is made
+that could reveal the user's address. The bounded incident ring contains only
+relative ages, generations, safe reason codes, scheduler/resource evidence and
+recovery outcomes; it never stores URLs, IPs, credentials, subscription data or
+traffic metadata.
+
+The WebView watchdog remains a UI/guard-only observer. It can pause the quality
+engine and reconcile WFP, but it does not race native recovery. Its legacy
+frontend candidate path is retained only as an explicit fallback for snapshots
+without a native owner; candidate validation uses the fixed dataplane probe,
+preserves the original selector and rolls back before full reconnect.
 
 For the release ritual, see [RELEASING.md](../RELEASING.md).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -104,7 +104,8 @@ The native monitor has the following lifecycle states:
 inactive → unknown → suspect → healthy
                     └──────→ failed → recovering → unknown (new generation)
                                       └──────────→ cooldown/pressure_wait
-                                      └──────────→ terminal or cleanup_error
+                                      └──────────→ terminal_cleanup → terminal
+                                                    └──────────────→ cleanup_error
 ```
 
 Recovery is owned by one native controller. It retains the in-memory launch
@@ -127,9 +128,11 @@ recovery outcomes; it never stores URLs, IPs, credentials, subscription data or
 traffic metadata.
 
 The WebView watchdog remains a UI/guard-only observer. It can pause the quality
-engine and reconcile WFP, but it does not race native recovery. Its legacy
-frontend candidate path is retained only as an explicit fallback for snapshots
-without a native owner; candidate validation uses the fixed dataplane probe,
-preserves the original selector and rolls back before full reconnect.
+engine and reconcile WFP, but it does not race native recovery. After native
+fail-closed cleanup has been confirmed, a responsive WebView may use the
+existing bounded candidate/reconnect fallback; a hung WebView leaves the native
+barrier in place. Candidate validation uses the fixed dataplane probe, preserves
+the original selector and rolls back before full reconnect. Strict privacy keeps
+its pinned-node policy and skips candidate switching.
 
 For the release ritual, see [RELEASING.md](../RELEASING.md).

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -72,6 +72,7 @@ windows = { version = "0.62", features = [
     "Win32_System_Com",
     "Win32_System_Ole",
     "Win32_System_Registry",
+    "Win32_System_SystemInformation",
     "Win32_System_Threading",
     "Win32_System_Variant",
     "Win32_UI_Shell",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -71,6 +71,7 @@ windows = { version = "0.62", features = [
     "Win32_Storage_FileSystem",
     "Win32_System_Com",
     "Win32_System_Ole",
+    "Win32_System_ProcessStatus",
     "Win32_System_Registry",
     "Win32_System_SystemInformation",
     "Win32_System_Threading",

--- a/src-tauri/src/health.rs
+++ b/src-tauri/src/health.rs
@@ -1,0 +1,362 @@
+//! Native dataplane health monitor.
+//!
+//! Process liveness is not enough for a VPN runtime: sing-box can stay alive
+//! while its TUN/proxy datapath is starved by the host. This module keeps a
+//! small native probe running outside the WebView timer and publishes only a
+//! bounded, non-sensitive health snapshot to the frontend.
+
+use serde::Serialize;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use tauri::{AppHandle, Emitter};
+
+use crate::quality;
+use crate::util::MutexExt;
+
+const INITIAL_DELAY: Duration = Duration::from_secs(4);
+const HEALTH_INTERVAL: Duration = Duration::from_secs(10);
+const PRESSURE_INTERVAL: Duration = Duration::from_secs(15);
+const PROBE_BUDGET_MS: u64 = 2_500;
+const PROBE_BYTES: u64 = 64 * 1024;
+const SCHEDULER_PRESSURE_MS: u64 = 1_500;
+const FAILED_PROBES: u32 = 2;
+const PRESSURE_MEMORY_LOAD_PERCENT: u32 = 95;
+const PRESSURE_AVAILABLE_MEMORY_BYTES: u64 = 512 * 1024 * 1024;
+const HEALTH_EVENT: &str = "ninety:dataplane-health";
+
+const WATCHDOG_ENDPOINTS: &[&str] = &["https://speed.cloudflare.com/__down?bytes=65536"];
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DataplaneHealthSnapshot {
+    pub state: String,
+    pub reason: Option<String>,
+    pub generation: u64,
+    pub consecutive_failures: u32,
+    pub last_probe_ms: u64,
+    pub last_probe_age_ms: Option<u64>,
+    pub scheduler_lateness_ms: u64,
+    pub host_pressure: bool,
+    pub memory_load_percent: Option<u32>,
+    pub available_memory_bytes: Option<u64>,
+}
+
+impl Default for DataplaneHealthSnapshot {
+    fn default() -> Self {
+        Self {
+            state: "inactive".into(),
+            reason: None,
+            generation: 0,
+            consecutive_failures: 0,
+            last_probe_ms: 0,
+            last_probe_age_ms: None,
+            scheduler_lateness_ms: 0,
+            host_pressure: false,
+            memory_load_percent: None,
+            available_memory_bytes: None,
+        }
+    }
+}
+
+struct HealthInner {
+    state: String,
+    reason: Option<String>,
+    generation: u64,
+    consecutive_failures: u32,
+    last_probe_at: Option<Instant>,
+    last_probe_ms: u64,
+    scheduler_lateness_ms: u64,
+    host_pressure: bool,
+    memory_load_percent: Option<u32>,
+    available_memory_bytes: Option<u64>,
+}
+
+impl Default for HealthInner {
+    fn default() -> Self {
+        Self {
+            state: "inactive".into(),
+            reason: None,
+            generation: 0,
+            consecutive_failures: 0,
+            last_probe_at: None,
+            last_probe_ms: 0,
+            scheduler_lateness_ms: 0,
+            host_pressure: false,
+            memory_load_percent: None,
+            available_memory_bytes: None,
+        }
+    }
+}
+
+/// Shared state is deliberately separate from the task handle. A stale task
+/// must never be able to overwrite a later runtime generation after stop/start.
+pub struct DataplaneHealthState(Mutex<HealthInner>);
+
+impl Default for DataplaneHealthState {
+    fn default() -> Self {
+        Self(Mutex::new(HealthInner::default()))
+    }
+}
+
+impl DataplaneHealthState {
+    pub fn reset_active(&self, generation: u64) {
+        let mut inner = self.0.lock_recover();
+        *inner = HealthInner {
+            state: "unknown".into(),
+            generation,
+            ..HealthInner::default()
+        };
+    }
+
+    pub fn reset_inactive(&self) {
+        *self.0.lock_recover() = HealthInner::default();
+    }
+
+    pub fn snapshot(&self) -> DataplaneHealthSnapshot {
+        let inner = self.0.lock_recover();
+        DataplaneHealthSnapshot {
+            state: inner.state.clone(),
+            reason: inner.reason.clone(),
+            generation: inner.generation,
+            consecutive_failures: inner.consecutive_failures,
+            last_probe_ms: inner.last_probe_ms,
+            last_probe_age_ms: inner
+                .last_probe_at
+                .map(|at| at.elapsed().as_millis().min(u64::MAX as u128) as u64),
+            scheduler_lateness_ms: inner.scheduler_lateness_ms,
+            host_pressure: inner.host_pressure,
+            memory_load_percent: inner.memory_load_percent,
+            available_memory_bytes: inner.available_memory_bytes,
+        }
+    }
+
+    fn record(
+        &self,
+        generation: u64,
+        state: &str,
+        reason: Option<&str>,
+        consecutive_failures: u32,
+        probe_ms: u64,
+        scheduler_lateness_ms: u64,
+        resources: ResourceSample,
+    ) {
+        let mut inner = self.0.lock_recover();
+        if inner.generation != generation {
+            return;
+        }
+        inner.state = state.into();
+        inner.reason = reason.map(str::to_owned);
+        inner.consecutive_failures = consecutive_failures;
+        inner.last_probe_at = Some(Instant::now());
+        inner.last_probe_ms = probe_ms;
+        inner.scheduler_lateness_ms = scheduler_lateness_ms;
+        inner.host_pressure = resources.pressure;
+        inner.memory_load_percent = resources.memory_load_percent;
+        inner.available_memory_bytes = resources.available_memory_bytes;
+    }
+}
+
+#[derive(Clone, Copy, Default)]
+struct ResourceSample {
+    pressure: bool,
+    memory_load_percent: Option<u32>,
+    available_memory_bytes: Option<u64>,
+}
+
+#[cfg(target_os = "windows")]
+fn resource_sample() -> ResourceSample {
+    use windows::Win32::System::SystemInformation::{GlobalMemoryStatusEx, MEMORYSTATUSEX};
+
+    let mut status = MEMORYSTATUSEX {
+        dwLength: std::mem::size_of::<MEMORYSTATUSEX>() as u32,
+        ..Default::default()
+    };
+    let Ok(()) = (unsafe { GlobalMemoryStatusEx(&mut status) }) else {
+        return ResourceSample::default();
+    };
+    let available = status.ullAvailPhys;
+    let load = status.dwMemoryLoad;
+    ResourceSample {
+        pressure: load >= PRESSURE_MEMORY_LOAD_PERCENT
+            || available <= PRESSURE_AVAILABLE_MEMORY_BYTES,
+        memory_load_percent: Some(load),
+        available_memory_bytes: Some(available),
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+fn resource_sample() -> ResourceSample {
+    ResourceSample::default()
+}
+
+fn probe_ok(result: &quality::ProbeResult) -> bool {
+    result.ok && !result.stalled && result.bytes >= PROBE_BYTES
+}
+
+fn probe_reason(result: &quality::ProbeResult) -> &'static str {
+    if result.stalled {
+        "dataplane_stalled"
+    } else if result.error.is_some() {
+        "dataplane_probe_failed"
+    } else {
+        "dataplane_probe_incomplete"
+    }
+}
+
+fn publish(app: &AppHandle, health: &DataplaneHealthState) {
+    let _ = app.emit(HEALTH_EVENT, health.snapshot());
+}
+
+/// Starts one native monitor for one runtime generation.
+///
+/// The monitor intentionally does not perform recovery itself yet: recovery
+/// still needs frontend-owned profile/config selection. It does, however,
+/// keep the observation and pressure classification alive outside WebView
+/// timers and supplies the recovery controller with a trustworthy signal.
+pub fn start_dataplane_watchdog(
+    app: AppHandle,
+    health: Arc<DataplaneHealthState>,
+    generation_token: Arc<AtomicU64>,
+    generation: u64,
+    probe_port: u16,
+) {
+    generation_token.store(generation, Ordering::SeqCst);
+    health.reset_active(generation);
+    publish(&app, &health);
+
+    tauri::async_runtime::spawn(async move {
+        tokio::time::sleep(INITIAL_DELAY).await;
+        let mut next = Instant::now();
+        let mut failures = 0u32;
+
+        loop {
+            if generation_token.load(Ordering::SeqCst) != generation {
+                break;
+            }
+            let scheduled = next;
+            let now = Instant::now();
+            if now < scheduled {
+                tokio::time::sleep(scheduled.duration_since(now)).await;
+            }
+            if generation_token.load(Ordering::SeqCst) != generation {
+                break;
+            }
+
+            let started = Instant::now();
+            let lateness = started
+                .saturating_duration_since(scheduled)
+                .as_millis()
+                .min(u64::MAX as u128) as u64;
+            let resources = resource_sample();
+            let result = quality::probe_quality_inner(
+                Some(probe_port),
+                WATCHDOG_ENDPOINTS.iter().map(|url| (*url).into()).collect(),
+                Some(PROBE_BYTES),
+                Some(PROBE_BUDGET_MS),
+            )
+            .await;
+            if generation_token.load(Ordering::SeqCst) != generation {
+                break;
+            }
+
+            let probe_ms = started.elapsed().as_millis().min(u64::MAX as u128) as u64;
+            let scheduler_pressure = lateness >= SCHEDULER_PRESSURE_MS;
+            let pressure = scheduler_pressure || resources.pressure;
+            let (state, reason, current_failures) = match result {
+                Ok(ref probe) if probe_ok(probe) && !pressure => {
+                    failures = 0;
+                    ("healthy", None, failures)
+                }
+                Ok(ref probe) if pressure => {
+                    failures = 0;
+                    ("pressure", Some("host_resource_pressure"), failures)
+                }
+                Err(_) if pressure => {
+                    failures = 0;
+                    ("pressure", Some("host_resource_pressure"), failures)
+                }
+                Ok(ref probe) => {
+                    failures = failures.saturating_add(1);
+                    let state = if failures >= FAILED_PROBES {
+                        "failed"
+                    } else {
+                        "suspect"
+                    };
+                    (state, Some(probe_reason(probe)), failures)
+                }
+                Err(_) => {
+                    failures = failures.saturating_add(1);
+                    let state = if failures >= FAILED_PROBES {
+                        "failed"
+                    } else {
+                        "suspect"
+                    };
+                    (state, Some("dataplane_probe_error"), failures)
+                }
+            };
+
+            health.record(
+                generation,
+                state,
+                reason,
+                current_failures,
+                probe_ms,
+                lateness,
+                ResourceSample {
+                    pressure,
+                    ..resources
+                },
+            );
+            publish(&app, &health);
+            next = Instant::now()
+                + if pressure {
+                    PRESSURE_INTERVAL
+                } else {
+                    HEALTH_INTERVAL
+                };
+        }
+    });
+}
+
+pub fn stop_dataplane_watchdog(health: &DataplaneHealthState, generation_token: &AtomicU64) {
+    generation_token.store(0, Ordering::SeqCst);
+    health.reset_inactive();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_health_is_inactive() {
+        let health = DataplaneHealthState::default();
+        assert_eq!(health.snapshot().state, "inactive");
+    }
+
+    #[test]
+    fn active_health_starts_unknown_and_keeps_generation() {
+        let health = DataplaneHealthState::default();
+        health.reset_active(42);
+        let snapshot = health.snapshot();
+        assert_eq!(snapshot.state, "unknown");
+        assert_eq!(snapshot.generation, 42);
+    }
+
+    #[test]
+    fn stale_generation_cannot_overwrite_new_runtime_health() {
+        let health = DataplaneHealthState::default();
+        health.reset_active(42);
+        health.record(
+            41,
+            "failed",
+            Some("stale"),
+            2,
+            100,
+            0,
+            ResourceSample::default(),
+        );
+        assert_eq!(health.snapshot().state, "unknown");
+    }
+}

--- a/src-tauri/src/health.rs
+++ b/src-tauri/src/health.rs
@@ -879,6 +879,7 @@ fn record_incident(
 
 #[cfg(target_os = "windows")]
 fn resource_sample() -> ResourceSample {
+    use windows::Win32::System::ProcessStatus::{GetPerformanceInfo, PERFORMANCE_INFORMATION};
     use windows::Win32::System::SystemInformation::{GlobalMemoryStatusEx, MEMORYSTATUSEX};
 
     let mut status = MEMORYSTATUSEX {
@@ -888,10 +889,26 @@ fn resource_sample() -> ResourceSample {
     let Ok(()) = (unsafe { GlobalMemoryStatusEx(&mut status) }) else {
         return ResourceSample::default();
     };
+    let mut performance = PERFORMANCE_INFORMATION {
+        cb: std::mem::size_of::<PERFORMANCE_INFORMATION>() as u32,
+        ..Default::default()
+    };
+    let performance_cb = performance.cb;
+    let available_commit_bytes =
+        if unsafe { GetPerformanceInfo(&mut performance, performance_cb) }.is_ok() {
+            Some(
+                (performance
+                    .CommitLimit
+                    .saturating_sub(performance.CommitTotal) as u64)
+                    .saturating_mul(performance.PageSize as u64),
+            )
+        } else {
+            None
+        };
     ResourceSample {
         memory_load_percent: Some(status.dwMemoryLoad),
         available_memory_bytes: Some(status.ullAvailPhys),
-        available_commit_bytes: Some(status.ullAvailPageFile),
+        available_commit_bytes,
         available_pagefile_bytes: Some(status.ullAvailPageFile),
         cpu_load_percent: None,
     }

--- a/src-tauri/src/health.rs
+++ b/src-tauri/src/health.rs
@@ -73,6 +73,15 @@ struct HealthInner {
     available_memory_bytes: Option<u64>,
 }
 
+struct HealthRecord {
+    state: &'static str,
+    reason: Option<&'static str>,
+    consecutive_failures: u32,
+    probe_ms: u64,
+    scheduler_lateness_ms: u64,
+    resources: ResourceSample,
+}
+
 impl Default for HealthInner {
     fn default() -> Self {
         Self {
@@ -132,29 +141,20 @@ impl DataplaneHealthState {
         }
     }
 
-    fn record(
-        &self,
-        generation: u64,
-        state: &str,
-        reason: Option<&str>,
-        consecutive_failures: u32,
-        probe_ms: u64,
-        scheduler_lateness_ms: u64,
-        resources: ResourceSample,
-    ) {
+    fn record(&self, generation: u64, update: HealthRecord) {
         let mut inner = self.0.lock_recover();
         if inner.generation != generation {
             return;
         }
-        inner.state = state.into();
-        inner.reason = reason.map(str::to_owned);
-        inner.consecutive_failures = consecutive_failures;
+        inner.state = update.state.into();
+        inner.reason = update.reason.map(str::to_owned);
+        inner.consecutive_failures = update.consecutive_failures;
         inner.last_probe_at = Some(Instant::now());
-        inner.last_probe_ms = probe_ms;
-        inner.scheduler_lateness_ms = scheduler_lateness_ms;
-        inner.host_pressure = resources.pressure;
-        inner.memory_load_percent = resources.memory_load_percent;
-        inner.available_memory_bytes = resources.available_memory_bytes;
+        inner.last_probe_ms = update.probe_ms;
+        inner.scheduler_lateness_ms = update.scheduler_lateness_ms;
+        inner.host_pressure = update.resources.pressure;
+        inner.memory_load_percent = update.resources.memory_load_percent;
+        inner.available_memory_bytes = update.resources.available_memory_bytes;
     }
 }
 
@@ -299,14 +299,16 @@ pub fn start_dataplane_watchdog(
 
             health.record(
                 generation,
-                state,
-                reason,
-                current_failures,
-                probe_ms,
-                lateness,
-                ResourceSample {
-                    pressure,
-                    ..resources
+                HealthRecord {
+                    state,
+                    reason,
+                    consecutive_failures: current_failures,
+                    probe_ms,
+                    scheduler_lateness_ms: lateness,
+                    resources: ResourceSample {
+                        pressure,
+                        ..resources
+                    },
                 },
             );
             publish(&app, &health);
@@ -350,12 +352,14 @@ mod tests {
         health.reset_active(42);
         health.record(
             41,
-            "failed",
-            Some("stale"),
-            2,
-            100,
-            0,
-            ResourceSample::default(),
+            HealthRecord {
+                state: "failed",
+                reason: Some("stale"),
+                consecutive_failures: 2,
+                probe_ms: 100,
+                scheduler_lateness_ms: 0,
+                resources: ResourceSample::default(),
+            },
         );
         assert_eq!(health.snapshot().state, "unknown");
     }

--- a/src-tauri/src/health.rs
+++ b/src-tauri/src/health.rs
@@ -1098,6 +1098,7 @@ mod tests {
             health.recovery_decision(Instant::now()),
             RecoveryDecision::Allowed
         );
+        health.native_recovery_failed(42, "test_failure");
         assert_eq!(
             health.recovery_decision(Instant::now()),
             RecoveryDecision::Cooldown

--- a/src-tauri/src/health.rs
+++ b/src-tauri/src/health.rs
@@ -31,6 +31,9 @@ const PRESSURE_RECOVERY_WAIT: Duration = Duration::from_secs(20);
 const NATIVE_RECOVERY_COOLDOWN: Duration = Duration::from_secs(60);
 const NATIVE_RECOVERY_WINDOW: Duration = Duration::from_secs(15 * 60);
 const NATIVE_RECOVERY_MAX: usize = 3;
+const TERMINAL_CLEANUP_COOLDOWN: Duration = Duration::from_secs(60);
+const TERMINAL_CLEANUP_WINDOW: Duration = Duration::from_secs(15 * 60);
+const TERMINAL_CLEANUP_MAX: usize = 3;
 const PROBE_WINDOW_SIZE: usize = 3;
 const INCIDENT_RING_SIZE: usize = 32;
 
@@ -64,8 +67,14 @@ pub struct IncidentSnapshot {
     pub state: String,
     pub reason: Option<String>,
     pub scheduler_lateness_ms: u64,
+    pub probe_duration_ms: Option<u64>,
     pub probe_outcome: Option<String>,
     pub host_pressure: bool,
+    pub memory_load_percent: Option<u32>,
+    pub available_memory_bytes: Option<u64>,
+    pub available_commit_bytes: Option<u64>,
+    pub available_pagefile_bytes: Option<u64>,
+    pub cpu_load_percent: Option<u32>,
     pub recovery_action: Option<String>,
     pub recovery_outcome: Option<String>,
 }
@@ -184,8 +193,14 @@ struct Incident {
     state: String,
     reason: Option<String>,
     scheduler_lateness_ms: u64,
+    probe_duration_ms: Option<u64>,
     probe_outcome: Option<String>,
     host_pressure: bool,
+    memory_load_percent: Option<u32>,
+    available_memory_bytes: Option<u64>,
+    available_commit_bytes: Option<u64>,
+    available_pagefile_bytes: Option<u64>,
+    cpu_load_percent: Option<u32>,
     recovery_action: Option<String>,
     recovery_outcome: Option<String>,
 }
@@ -214,6 +229,7 @@ struct HealthInner {
     native_recovery_state: String,
     native_recovery_attempts: u32,
     native_recovery_times: VecDeque<Instant>,
+    terminal_cleanup_times: VecDeque<Instant>,
 }
 
 impl Default for HealthInner {
@@ -242,6 +258,7 @@ impl Default for HealthInner {
             native_recovery_state: "idle".into(),
             native_recovery_attempts: 0,
             native_recovery_times: VecDeque::new(),
+            terminal_cleanup_times: VecDeque::new(),
         }
     }
 }
@@ -371,8 +388,14 @@ impl DataplaneHealthState {
                     state: incident.state.clone(),
                     reason: incident.reason.clone(),
                     scheduler_lateness_ms: incident.scheduler_lateness_ms,
+                    probe_duration_ms: incident.probe_duration_ms,
                     probe_outcome: incident.probe_outcome.clone(),
                     host_pressure: incident.host_pressure,
+                    memory_load_percent: incident.memory_load_percent,
+                    available_memory_bytes: incident.available_memory_bytes,
+                    available_commit_bytes: incident.available_commit_bytes,
+                    available_pagefile_bytes: incident.available_pagefile_bytes,
+                    cpu_load_percent: incident.cpu_load_percent,
                     recovery_action: incident.recovery_action.clone(),
                     recovery_outcome: incident.recovery_outcome.clone(),
                 })
@@ -385,9 +408,22 @@ impl DataplaneHealthState {
         if inner.generation != generation {
             return;
         }
+        let pressure_was_active = inner.host_pressure;
         update_pressure(&mut inner, resources, scheduler);
         inner.scheduler_lateness_ms = scheduler;
         inner.resources = resources;
+        if !pressure_was_active && inner.host_pressure {
+            record_incident(
+                &mut inner,
+                generation,
+                "pressure",
+                Some("host_resource_pressure"),
+                scheduler,
+                Some("pressure_entered"),
+                None,
+                None,
+            );
+        }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -405,9 +441,22 @@ impl DataplaneHealthState {
         if inner.generation != generation {
             return;
         }
+        let pressure_was_active = inner.host_pressure;
         update_pressure(&mut inner, resources, scheduler);
         inner.scheduler_lateness_ms = scheduler;
         inner.resources = resources;
+        if !pressure_was_active && inner.host_pressure {
+            record_incident(
+                &mut inner,
+                generation,
+                "pressure",
+                Some("host_resource_pressure"),
+                scheduler,
+                Some("pressure_entered"),
+                None,
+                None,
+            );
+        }
         inner.last_probe_at = Some(Instant::now());
         inner.last_probe_ms = duration_ms;
         if success {
@@ -429,13 +478,12 @@ impl DataplaneHealthState {
             bytes,
         });
 
-        let success_count = inner
+        let failure_count = inner
             .probe_window
             .iter()
-            .filter(|sample| sample.success)
+            .filter(|sample| !sample.success)
             .count();
-        let failure_count = inner.probe_window.len().saturating_sub(success_count);
-        if success_count >= 2 {
+        if inner.consecutive_successes >= 2 {
             inner.dataplane_state = "healthy".into();
             inner.reason = None;
         } else if failure_count >= 2 {
@@ -480,22 +528,67 @@ impl DataplaneHealthState {
         if inner.generation != generation {
             return;
         }
+        let pressure_was_active = inner.host_pressure;
         update_pressure(&mut inner, resources, scheduler);
         inner.scheduler_lateness_ms = scheduler;
         inner.resources = resources;
+        if !pressure_was_active && inner.host_pressure {
+            record_incident(
+                &mut inner,
+                generation,
+                "pressure",
+                Some("host_resource_pressure"),
+                scheduler,
+                Some("pressure_entered"),
+                None,
+                None,
+            );
+        }
         inner.last_probe_at = Some(Instant::now());
         inner.last_probe_ms = duration_ms;
+        if local_ok {
+            inner.last_successful_probe_at = inner.last_probe_at;
+            inner.consecutive_successes = inner.consecutive_successes.saturating_add(1);
+            inner.consecutive_failures = 0;
+        } else {
+            inner.consecutive_failures = inner.consecutive_failures.saturating_add(1);
+            inner.consecutive_successes = 0;
+        }
         inner.unmonitored_privacy_mode = true;
         inner.monitoring_mode = "privacy_passive".into();
-        if local_ok {
+        if inner.probe_window.len() == PROBE_WINDOW_SIZE {
+            inner.probe_window.pop_front();
+        }
+        inner.probe_window.push_back(ProbeSample {
+            at: Instant::now(),
+            success: local_ok,
+            reason: reason.map(str::to_owned),
+            duration_ms,
+            bytes: 0,
+        });
+        let failure_count = inner
+            .probe_window
+            .iter()
+            .filter(|sample| !sample.success)
+            .count();
+        if inner.consecutive_successes >= 2 {
             inner.dataplane_state = "unmonitoredPrivacyMode".into();
-            inner.state = "unmonitoredPrivacyMode".into();
             inner.reason = None;
-        } else {
+        } else if failure_count >= 2 {
             inner.dataplane_state = "failed".into();
-            inner.state = "failed".into();
+            inner.reason = reason.map(str::to_owned);
+        } else {
+            inner.dataplane_state = "suspect".into();
             inner.reason = reason.map(str::to_owned);
         }
+        inner.state = if inner.dataplane_state == "failed" {
+            "failed"
+        } else if inner.host_pressure {
+            "pressure"
+        } else {
+            inner.dataplane_state.as_str()
+        }
+        .into();
         let incident_state = inner.state.clone();
         let incident_reason = inner.reason.clone();
         record_incident(
@@ -558,6 +651,44 @@ impl DataplaneHealthState {
             Some("started"),
         );
         RecoveryDecision::Allowed
+    }
+
+    fn terminal_cleanup_decision(&self, now: Instant) -> TerminalCleanupDecision {
+        let mut inner = self.inner.lock_recover();
+        while inner
+            .terminal_cleanup_times
+            .front()
+            .is_some_and(|at| now.saturating_duration_since(*at) >= TERMINAL_CLEANUP_WINDOW)
+        {
+            inner.terminal_cleanup_times.pop_front();
+        }
+        if inner.native_recovery_state == "terminal"
+            || inner.terminal_cleanup_times.len() >= TERMINAL_CLEANUP_MAX
+        {
+            return TerminalCleanupDecision::Exhausted;
+        }
+        if let Some(last) = inner.terminal_cleanup_times.back() {
+            if now.saturating_duration_since(*last) < TERMINAL_CLEANUP_COOLDOWN {
+                return TerminalCleanupDecision::Cooldown;
+            }
+        }
+
+        inner.terminal_cleanup_times.push_back(now);
+        inner.native_recovery_state = "terminal_cleanup".into();
+        let generation = inner.generation;
+        let incident_reason = inner.reason.clone();
+        let scheduler_lateness = inner.scheduler_lateness_ms;
+        record_incident(
+            &mut inner,
+            generation,
+            "cleanup_error",
+            incident_reason.as_deref(),
+            scheduler_lateness,
+            None,
+            Some("fail_closed_cleanup"),
+            Some("started"),
+        );
+        TerminalCleanupDecision::Allowed
     }
 
     pub fn native_recovery_failed(&self, generation: u64, reason: &str) {
@@ -647,6 +778,13 @@ enum RecoveryDecision {
     Exhausted,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum TerminalCleanupDecision {
+    Allowed,
+    Cooldown,
+    Exhausted,
+}
+
 fn elapsed_ms(now: Instant, then: Instant) -> u64 {
     now.saturating_duration_since(then)
         .as_millis()
@@ -726,8 +864,14 @@ fn record_incident(
         state: state.into(),
         reason: reason.map(str::to_owned),
         scheduler_lateness_ms,
+        probe_duration_ms: inner.last_probe_at.map(|_| inner.last_probe_ms),
         probe_outcome: probe_outcome.map(str::to_owned),
         host_pressure: inner.host_pressure,
+        memory_load_percent: inner.resources.memory_load_percent,
+        available_memory_bytes: inner.resources.available_memory_bytes,
+        available_commit_bytes: inner.resources.available_commit_bytes,
+        available_pagefile_bytes: inner.resources.available_pagefile_bytes,
+        cpu_load_percent: inner.resources.cpu_load_percent,
         recovery_action: recovery_action.map(str::to_owned),
         recovery_outcome: recovery_outcome.map(str::to_owned),
     });
@@ -939,7 +1083,7 @@ pub fn start_dataplane_watchdog(
 
             let snapshot = health.snapshot();
             let failed = snapshot.dataplane_state == "failed";
-            if failed && !strict_privacy {
+            if failed {
                 match health.recovery_decision(Instant::now()) {
                     RecoveryDecision::Allowed => {
                         publish(&app, &health);
@@ -954,35 +1098,19 @@ pub fn start_dataplane_watchdog(
                         publish(&app, &health);
                     }
                     RecoveryDecision::Exhausted => {
-                        let cleanup_confirmed =
-                            crate::vpn::native_terminal_fail_closed(&app, generation).await;
-                        health.native_terminal_result(generation, cleanup_confirmed);
-                        publish(&app, &health);
-                        break;
-                    }
-                    RecoveryDecision::Busy
-                    | RecoveryDecision::Cooldown
-                    | RecoveryDecision::PressureWait => {}
-                }
-            } else if failed && strict_privacy {
-                // Strict privacy never creates an external probe. Local/API
-                // failure is still recoverable natively, with the same budget.
-                match health.recovery_decision(Instant::now()) {
-                    RecoveryDecision::Allowed => {
-                        let recovered =
-                            crate::vpn::native_recover_current_runtime(&app, generation).await;
-                        if recovered {
-                            break;
+                        match health.terminal_cleanup_decision(Instant::now()) {
+                            TerminalCleanupDecision::Allowed => {
+                                let cleanup_confirmed =
+                                    crate::vpn::native_terminal_fail_closed(&app, generation).await;
+                                health.native_terminal_result(generation, cleanup_confirmed);
+                                publish(&app, &health);
+                                if cleanup_confirmed {
+                                    break;
+                                }
+                            }
+                            TerminalCleanupDecision::Cooldown
+                            | TerminalCleanupDecision::Exhausted => {}
                         }
-                        health.native_recovery_failed(generation, "native_recovery_failed");
-                        publish(&app, &health);
-                    }
-                    RecoveryDecision::Exhausted => {
-                        let cleanup_confirmed =
-                            crate::vpn::native_terminal_fail_closed(&app, generation).await;
-                        health.native_terminal_result(generation, cleanup_confirmed);
-                        publish(&app, &health);
-                        break;
                     }
                     RecoveryDecision::Busy
                     | RecoveryDecision::Cooldown
@@ -1056,6 +1184,18 @@ mod tests {
     }
 
     #[test]
+    fn rolling_window_requires_consecutive_successes_for_healthy() {
+        let health = DataplaneHealthState::default();
+        health.reset_active_for_runtime(42, false, false);
+        sample(&health, 42, true);
+        sample(&health, 42, false);
+        sample(&health, 42, true);
+        assert_eq!(health.snapshot().dataplane_state, "suspect");
+        sample(&health, 42, true);
+        assert_eq!(health.snapshot().dataplane_state, "healthy");
+    }
+
+    #[test]
     fn pressure_does_not_erase_dataplane_failure() {
         let health = DataplaneHealthState::default();
         health.reset_active_for_runtime(42, false, false);
@@ -1076,6 +1216,67 @@ mod tests {
         let snapshot = health.snapshot();
         assert_eq!(snapshot.dataplane_state, "failed");
         assert!(snapshot.host_pressure);
+    }
+
+    #[test]
+    fn pressure_incident_keeps_safe_resource_evidence() {
+        let health = DataplaneHealthState::default();
+        health.reset_active_for_runtime(42, false, false);
+        health.set_resources(
+            42,
+            ResourceSample {
+                memory_load_percent: Some(99),
+                available_memory_bytes: Some(128 * 1024 * 1024),
+                available_commit_bytes: Some(256 * 1024 * 1024),
+                available_pagefile_bytes: Some(512 * 1024 * 1024),
+                cpu_load_percent: Some(97),
+            },
+            2_000,
+        );
+        let incident = health
+            .snapshot()
+            .incidents
+            .pop()
+            .expect("pressure incident");
+        assert_eq!(incident.reason.as_deref(), Some("host_resource_pressure"));
+        assert_eq!(incident.probe_duration_ms, None);
+        assert_eq!(incident.memory_load_percent, Some(99));
+        assert_eq!(incident.available_memory_bytes, Some(128 * 1024 * 1024));
+        assert_eq!(incident.available_commit_bytes, Some(256 * 1024 * 1024));
+        assert_eq!(incident.available_pagefile_bytes, Some(512 * 1024 * 1024));
+        assert_eq!(incident.cpu_load_percent, Some(97));
+    }
+
+    #[test]
+    fn strict_privacy_uses_explicit_passive_state() {
+        let health = DataplaneHealthState::default();
+        health.reset_active_for_runtime(42, true, false);
+        let initial = health.snapshot();
+        assert_eq!(initial.state, "unmonitoredPrivacyMode");
+        assert!(initial.unmonitored_privacy_mode);
+        assert_eq!(initial.monitoring_mode, "privacy_passive");
+
+        health.record_passive(
+            42,
+            false,
+            Some("control_api_unreachable"),
+            12,
+            ResourceSample::default(),
+            0,
+        );
+        assert_eq!(health.snapshot().dataplane_state, "suspect");
+        health.record_passive(
+            42,
+            false,
+            Some("control_api_unreachable"),
+            12,
+            ResourceSample::default(),
+            0,
+        );
+        let failed = health.snapshot();
+        assert_eq!(failed.dataplane_state, "failed");
+        assert_eq!(failed.reason.as_deref(), Some("control_api_unreachable"));
+        assert!(failed.unmonitored_privacy_mode);
     }
 
     #[test]
@@ -1112,6 +1313,41 @@ mod tests {
             health.recovery_decision(Instant::now()),
             RecoveryDecision::Exhausted
         );
+    }
+
+    #[test]
+    fn terminal_cleanup_is_retryable_but_bounded() {
+        let health = DataplaneHealthState::default();
+        health.reset_active_for_runtime(42, false, false);
+        let first = Instant::now();
+        assert_eq!(
+            health.terminal_cleanup_decision(first),
+            TerminalCleanupDecision::Allowed
+        );
+        health.native_terminal_result(42, false);
+        assert_eq!(
+            health.terminal_cleanup_decision(first + Duration::from_secs(1)),
+            TerminalCleanupDecision::Cooldown
+        );
+
+        let second = first + TERMINAL_CLEANUP_COOLDOWN;
+        assert_eq!(
+            health.terminal_cleanup_decision(second),
+            TerminalCleanupDecision::Allowed
+        );
+        health.native_terminal_result(42, false);
+        let third = second + TERMINAL_CLEANUP_COOLDOWN;
+        assert_eq!(
+            health.terminal_cleanup_decision(third),
+            TerminalCleanupDecision::Allowed
+        );
+        health.native_terminal_result(42, false);
+
+        assert_eq!(
+            health.terminal_cleanup_decision(third + TERMINAL_CLEANUP_COOLDOWN),
+            TerminalCleanupDecision::Exhausted
+        );
+        assert_eq!(health.snapshot().native_recovery_state, "cleanup_error");
     }
 
     #[test]

--- a/src-tauri/src/health.rs
+++ b/src-tauri/src/health.rs
@@ -158,13 +158,13 @@ impl ResourceSample {
 
     fn pressure_recovered(self, scheduler_lateness_ms: u64) -> bool {
         self.memory_load_percent
-            .map_or(true, |value| value <= PRESSURE_MEMORY_LOAD_EXIT_PERCENT)
-            && self.available_memory_bytes.map_or(true, |value| {
-                value >= PRESSURE_AVAILABLE_PHYSICAL_EXIT_BYTES
-            })
+            .is_none_or(|value| value <= PRESSURE_MEMORY_LOAD_EXIT_PERCENT)
+            && self
+                .available_memory_bytes
+                .is_none_or(|value| value >= PRESSURE_AVAILABLE_PHYSICAL_EXIT_BYTES)
             && self
                 .available_commit_bytes
-                .map_or(true, |value| value >= PRESSURE_AVAILABLE_COMMIT_EXIT_BYTES)
+                .is_none_or(|value| value >= PRESSURE_AVAILABLE_COMMIT_EXIT_BYTES)
             && scheduler_lateness_ms <= PRESSURE_SCHEDULER_EXIT_MS
     }
 }
@@ -263,10 +263,6 @@ impl Default for DataplaneHealthState {
 }
 
 impl DataplaneHealthState {
-    pub fn reset_active(&self, generation: u64) {
-        self.reset_active_for_runtime(generation, false, false);
-    }
-
     pub fn reset_active_for_runtime(
         &self,
         generation: u64,
@@ -394,6 +390,7 @@ impl DataplaneHealthState {
         inner.resources = resources;
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn record_probe(
         &self,
         generation: u64,
@@ -709,6 +706,7 @@ fn pressure_reason(resources: ResourceSample, scheduler: u64) -> &'static str {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn record_incident(
     inner: &mut HealthInner,
     generation: u64,
@@ -1037,7 +1035,7 @@ mod tests {
     #[test]
     fn active_health_starts_unknown_and_keeps_generation() {
         let health = DataplaneHealthState::default();
-        health.reset_active(42);
+        health.reset_active_for_runtime(42, false, false);
         let snapshot = health.snapshot();
         assert_eq!(snapshot.state, "unknown");
         assert_eq!(snapshot.generation, 42);
@@ -1046,7 +1044,7 @@ mod tests {
     #[test]
     fn rolling_window_marks_fsf_failed_and_two_successes_healthy() {
         let health = DataplaneHealthState::default();
-        health.reset_active(42);
+        health.reset_active_for_runtime(42, false, false);
         sample(&health, 42, false);
         sample(&health, 42, true);
         sample(&health, 42, false);
@@ -1060,7 +1058,7 @@ mod tests {
     #[test]
     fn pressure_does_not_erase_dataplane_failure() {
         let health = DataplaneHealthState::default();
-        health.reset_active(42);
+        health.reset_active_for_runtime(42, false, false);
         sample(&health, 42, false);
         sample(&health, 42, false);
         {
@@ -1083,7 +1081,7 @@ mod tests {
     #[test]
     fn stale_generation_cannot_overwrite_new_runtime_health() {
         let health = DataplaneHealthState::default();
-        health.reset_active(42);
+        health.reset_active_for_runtime(42, false, false);
         sample(&health, 41, false);
         assert_eq!(health.snapshot().state, "unknown");
     }
@@ -1091,7 +1089,7 @@ mod tests {
     #[test]
     fn recovery_budget_distinguishes_cooldown_and_exhaustion() {
         let health = DataplaneHealthState::default();
-        health.reset_active(42);
+        health.reset_active_for_runtime(42, false, false);
         sample(&health, 42, false);
         sample(&health, 42, false);
         assert_eq!(
@@ -1119,7 +1117,7 @@ mod tests {
     #[test]
     fn incident_ring_is_bounded() {
         let health = DataplaneHealthState::default();
-        health.reset_active(42);
+        health.reset_active_for_runtime(42, false, false);
         for _ in 0..(INCIDENT_RING_SIZE + 5) {
             sample(&health, 42, false);
         }

--- a/src-tauri/src/health.rs
+++ b/src-tauri/src/health.rs
@@ -1,11 +1,17 @@
 //! Native dataplane health monitor.
 //!
-//! Process liveness is not enough for a VPN runtime: sing-box can stay alive
-//! while its TUN/proxy datapath is starved by the host. This module keeps a
-//! small native probe running outside the WebView timer and publishes only a
-//! bounded, non-sensitive health snapshot to the frontend.
+//! The monitor deliberately keeps three concerns separate:
+//!
+//! * dataplane liveness is decided from a bounded rolling window;
+//! * host pressure is a hysteretic signal and never erases dataplane failures;
+//! * recovery is owned by one native controller, not by a WebView timer.
+//!
+//! Only bounded, safe fields leave this module. Probe URLs, IP addresses,
+//! subscription data, credentials and traffic metadata never enter the
+//! snapshot or the incident ring.
 
 use serde::Serialize;
+use std::collections::VecDeque;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -18,151 +24,715 @@ use crate::util::MutexExt;
 const INITIAL_DELAY: Duration = Duration::from_secs(4);
 const HEALTH_INTERVAL: Duration = Duration::from_secs(10);
 const PRESSURE_INTERVAL: Duration = Duration::from_secs(15);
-const PROBE_BUDGET_MS: u64 = 2_500;
-const PROBE_BYTES: u64 = 64 * 1024;
-const SCHEDULER_PRESSURE_MS: u64 = 1_500;
-const FAILED_PROBES: u32 = 2;
+const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(2);
+const HEALTH_PROBE_TIMEOUT: Duration = Duration::from_secs(6);
+const CONTROL_API_TIMEOUT: Duration = Duration::from_millis(1_200);
+const PRESSURE_RECOVERY_WAIT: Duration = Duration::from_secs(20);
+const NATIVE_RECOVERY_COOLDOWN: Duration = Duration::from_secs(60);
+const NATIVE_RECOVERY_WINDOW: Duration = Duration::from_secs(15 * 60);
+const NATIVE_RECOVERY_MAX: usize = 3;
+const PROBE_WINDOW_SIZE: usize = 3;
+const INCIDENT_RING_SIZE: usize = 32;
+
 const PRESSURE_MEMORY_LOAD_PERCENT: u32 = 95;
-const PRESSURE_AVAILABLE_MEMORY_BYTES: u64 = 512 * 1024 * 1024;
+const PRESSURE_MEMORY_LOAD_EXIT_PERCENT: u32 = 90;
+const PRESSURE_AVAILABLE_PHYSICAL_BYTES: u64 = 512 * 1024 * 1024;
+const PRESSURE_AVAILABLE_PHYSICAL_EXIT_BYTES: u64 = 1024 * 1024 * 1024;
+const PRESSURE_AVAILABLE_COMMIT_BYTES: u64 = 512 * 1024 * 1024;
+const PRESSURE_AVAILABLE_COMMIT_EXIT_BYTES: u64 = 1024 * 1024 * 1024;
+const PRESSURE_SCHEDULER_MS: u64 = 1_500;
+const PRESSURE_SCHEDULER_EXIT_MS: u64 = 500;
+const PRESSURE_EXIT_SAMPLES: u8 = 3;
+
 const HEALTH_EVENT: &str = "ninety:dataplane-health";
 
-const WATCHDOG_ENDPOINTS: &[&str] = &["https://speed.cloudflare.com/__down?bytes=65536"];
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProbeWindowEntry {
+    pub age_ms: u64,
+    pub success: bool,
+    pub reason: Option<String>,
+    pub duration_ms: u64,
+    pub bytes: u64,
+}
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IncidentSnapshot {
+    pub age_ms: u64,
+    pub generation: u64,
+    pub state: String,
+    pub reason: Option<String>,
+    pub scheduler_lateness_ms: u64,
+    pub probe_outcome: Option<String>,
+    pub host_pressure: bool,
+    pub recovery_action: Option<String>,
+    pub recovery_outcome: Option<String>,
+}
 
 #[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DataplaneHealthSnapshot {
+    /// Compatibility field for the existing frontend. `failed` is never
+    /// replaced by `pressure`; pressure is exposed independently below.
     pub state: String,
+    pub dataplane_state: String,
     pub reason: Option<String>,
     pub generation: u64,
     pub consecutive_failures: u32,
+    pub consecutive_successes: u32,
     pub last_probe_ms: u64,
     pub last_probe_age_ms: Option<u64>,
+    pub last_successful_probe_age_ms: Option<u64>,
     pub scheduler_lateness_ms: u64,
     pub host_pressure: bool,
+    pub pressure_reason: Option<String>,
+    pub pressure_since_age_ms: Option<u64>,
     pub memory_load_percent: Option<u32>,
     pub available_memory_bytes: Option<u64>,
+    pub available_commit_bytes: Option<u64>,
+    pub available_pagefile_bytes: Option<u64>,
+    pub cpu_load_percent: Option<u32>,
+    pub monitoring_mode: String,
+    pub unmonitored_privacy_mode: bool,
+    pub native_recovery_owner: String,
+    pub native_recovery_state: String,
+    pub native_recovery_attempts: u32,
+    pub probe_window: Vec<ProbeWindowEntry>,
+    pub incidents: Vec<IncidentSnapshot>,
 }
 
 impl Default for DataplaneHealthSnapshot {
     fn default() -> Self {
         Self {
             state: "inactive".into(),
+            dataplane_state: "inactive".into(),
             reason: None,
             generation: 0,
             consecutive_failures: 0,
+            consecutive_successes: 0,
             last_probe_ms: 0,
             last_probe_age_ms: None,
+            last_successful_probe_age_ms: None,
             scheduler_lateness_ms: 0,
             host_pressure: false,
+            pressure_reason: None,
+            pressure_since_age_ms: None,
             memory_load_percent: None,
             available_memory_bytes: None,
+            available_commit_bytes: None,
+            available_pagefile_bytes: None,
+            cpu_load_percent: None,
+            monitoring_mode: "inactive".into(),
+            unmonitored_privacy_mode: false,
+            native_recovery_owner: "none".into(),
+            native_recovery_state: "idle".into(),
+            native_recovery_attempts: 0,
+            probe_window: Vec::new(),
+            incidents: Vec::new(),
         }
     }
 }
 
+#[derive(Clone, Copy, Default)]
+struct ResourceSample {
+    memory_load_percent: Option<u32>,
+    available_memory_bytes: Option<u64>,
+    available_commit_bytes: Option<u64>,
+    available_pagefile_bytes: Option<u64>,
+    cpu_load_percent: Option<u32>,
+}
+
+impl ResourceSample {
+    fn pressure_entered(self, scheduler_lateness_ms: u64) -> bool {
+        self.memory_load_percent
+            .is_some_and(|value| value >= PRESSURE_MEMORY_LOAD_PERCENT)
+            || self
+                .available_memory_bytes
+                .is_some_and(|value| value <= PRESSURE_AVAILABLE_PHYSICAL_BYTES)
+            || self
+                .available_commit_bytes
+                .is_some_and(|value| value <= PRESSURE_AVAILABLE_COMMIT_BYTES)
+            || scheduler_lateness_ms >= PRESSURE_SCHEDULER_MS
+    }
+
+    fn pressure_recovered(self, scheduler_lateness_ms: u64) -> bool {
+        self.memory_load_percent
+            .map_or(true, |value| value <= PRESSURE_MEMORY_LOAD_EXIT_PERCENT)
+            && self.available_memory_bytes.map_or(true, |value| {
+                value >= PRESSURE_AVAILABLE_PHYSICAL_EXIT_BYTES
+            })
+            && self
+                .available_commit_bytes
+                .map_or(true, |value| value >= PRESSURE_AVAILABLE_COMMIT_EXIT_BYTES)
+            && scheduler_lateness_ms <= PRESSURE_SCHEDULER_EXIT_MS
+    }
+}
+
+#[derive(Clone)]
+struct ProbeSample {
+    at: Instant,
+    success: bool,
+    reason: Option<String>,
+    duration_ms: u64,
+    bytes: u64,
+}
+
+struct Incident {
+    at: Instant,
+    generation: u64,
+    state: String,
+    reason: Option<String>,
+    scheduler_lateness_ms: u64,
+    probe_outcome: Option<String>,
+    host_pressure: bool,
+    recovery_action: Option<String>,
+    recovery_outcome: Option<String>,
+}
+
 struct HealthInner {
     state: String,
+    dataplane_state: String,
     reason: Option<String>,
     generation: u64,
     consecutive_failures: u32,
+    consecutive_successes: u32,
     last_probe_at: Option<Instant>,
+    last_successful_probe_at: Option<Instant>,
     last_probe_ms: u64,
     scheduler_lateness_ms: u64,
     host_pressure: bool,
-    memory_load_percent: Option<u32>,
-    available_memory_bytes: Option<u64>,
-}
-
-struct HealthRecord {
-    state: &'static str,
-    reason: Option<&'static str>,
-    consecutive_failures: u32,
-    probe_ms: u64,
-    scheduler_lateness_ms: u64,
+    pressure_reason: Option<String>,
+    pressure_since: Option<Instant>,
+    pressure_exit_samples: u8,
     resources: ResourceSample,
+    monitoring_mode: String,
+    unmonitored_privacy_mode: bool,
+    probe_window: VecDeque<ProbeSample>,
+    incidents: VecDeque<Incident>,
+    native_recovery_owner: String,
+    native_recovery_state: String,
+    native_recovery_attempts: u32,
+    native_recovery_times: VecDeque<Instant>,
 }
 
 impl Default for HealthInner {
     fn default() -> Self {
         Self {
             state: "inactive".into(),
+            dataplane_state: "inactive".into(),
             reason: None,
             generation: 0,
             consecutive_failures: 0,
+            consecutive_successes: 0,
             last_probe_at: None,
+            last_successful_probe_at: None,
             last_probe_ms: 0,
             scheduler_lateness_ms: 0,
             host_pressure: false,
-            memory_load_percent: None,
-            available_memory_bytes: None,
+            pressure_reason: None,
+            pressure_since: None,
+            pressure_exit_samples: 0,
+            resources: ResourceSample::default(),
+            monitoring_mode: "inactive".into(),
+            unmonitored_privacy_mode: false,
+            probe_window: VecDeque::with_capacity(PROBE_WINDOW_SIZE),
+            incidents: VecDeque::with_capacity(INCIDENT_RING_SIZE),
+            native_recovery_owner: "none".into(),
+            native_recovery_state: "idle".into(),
+            native_recovery_attempts: 0,
+            native_recovery_times: VecDeque::new(),
         }
     }
 }
 
-/// Shared state is deliberately separate from the task handle. A stale task
-/// must never be able to overwrite a later runtime generation after stop/start.
-pub struct DataplaneHealthState(Mutex<HealthInner>);
+/// Shared state is separate from task handles. A stale task can update neither
+/// a later runtime generation nor its incident history.
+pub struct DataplaneHealthState {
+    inner: Mutex<HealthInner>,
+    heartbeat_lateness_ms: AtomicU64,
+}
 
 impl Default for DataplaneHealthState {
     fn default() -> Self {
-        Self(Mutex::new(HealthInner::default()))
+        Self {
+            inner: Mutex::new(HealthInner::default()),
+            heartbeat_lateness_ms: AtomicU64::new(0),
+        }
     }
 }
 
 impl DataplaneHealthState {
     pub fn reset_active(&self, generation: u64) {
-        let mut inner = self.0.lock_recover();
+        self.reset_active_for_runtime(generation, false, false);
+    }
+
+    pub fn reset_active_for_runtime(
+        &self,
+        generation: u64,
+        strict_privacy: bool,
+        preserve_recovery_budget: bool,
+    ) {
+        let mut inner = self.inner.lock_recover();
+        let old_attempts = if preserve_recovery_budget {
+            inner.native_recovery_attempts
+        } else {
+            0
+        };
+        let old_times = if preserve_recovery_budget {
+            inner.native_recovery_times.clone()
+        } else {
+            VecDeque::new()
+        };
+        let passive = strict_privacy;
         *inner = HealthInner {
-            state: "unknown".into(),
+            state: if passive {
+                "unmonitoredPrivacyMode".into()
+            } else {
+                "unknown".into()
+            },
+            dataplane_state: if passive {
+                "unmonitoredPrivacyMode".into()
+            } else {
+                "unknown".into()
+            },
             generation,
+            monitoring_mode: if passive {
+                "privacy_passive".into()
+            } else {
+                "active_probe".into()
+            },
+            unmonitored_privacy_mode: passive,
+            native_recovery_owner: "native".into(),
+            native_recovery_attempts: old_attempts,
+            native_recovery_times: old_times,
             ..HealthInner::default()
         };
     }
 
     pub fn reset_inactive(&self) {
-        *self.0.lock_recover() = HealthInner::default();
+        *self.inner.lock_recover() = HealthInner::default();
+        self.heartbeat_lateness_ms.store(0, Ordering::SeqCst);
+    }
+
+    fn set_heartbeat_lateness(&self, generation: u64, lateness_ms: u64) {
+        if self.inner.lock_recover().generation == generation {
+            self.heartbeat_lateness_ms
+                .store(lateness_ms, Ordering::SeqCst);
+        }
+    }
+
+    fn heartbeat_lateness(&self) -> u64 {
+        self.heartbeat_lateness_ms.load(Ordering::SeqCst)
     }
 
     pub fn snapshot(&self) -> DataplaneHealthSnapshot {
-        let inner = self.0.lock_recover();
+        let inner = self.inner.lock_recover();
+        let now = Instant::now();
         DataplaneHealthSnapshot {
             state: inner.state.clone(),
+            dataplane_state: inner.dataplane_state.clone(),
             reason: inner.reason.clone(),
             generation: inner.generation,
             consecutive_failures: inner.consecutive_failures,
+            consecutive_successes: inner.consecutive_successes,
             last_probe_ms: inner.last_probe_ms,
-            last_probe_age_ms: inner
-                .last_probe_at
-                .map(|at| at.elapsed().as_millis().min(u64::MAX as u128) as u64),
+            last_probe_age_ms: inner.last_probe_at.map(|at| elapsed_ms(now, at)),
+            last_successful_probe_age_ms: inner
+                .last_successful_probe_at
+                .map(|at| elapsed_ms(now, at)),
             scheduler_lateness_ms: inner.scheduler_lateness_ms,
             host_pressure: inner.host_pressure,
-            memory_load_percent: inner.memory_load_percent,
-            available_memory_bytes: inner.available_memory_bytes,
+            pressure_reason: inner.pressure_reason.clone(),
+            pressure_since_age_ms: inner.pressure_since.map(|at| elapsed_ms(now, at)),
+            memory_load_percent: inner.resources.memory_load_percent,
+            available_memory_bytes: inner.resources.available_memory_bytes,
+            available_commit_bytes: inner.resources.available_commit_bytes,
+            available_pagefile_bytes: inner.resources.available_pagefile_bytes,
+            cpu_load_percent: inner.resources.cpu_load_percent,
+            monitoring_mode: inner.monitoring_mode.clone(),
+            unmonitored_privacy_mode: inner.unmonitored_privacy_mode,
+            native_recovery_owner: inner.native_recovery_owner.clone(),
+            native_recovery_state: inner.native_recovery_state.clone(),
+            native_recovery_attempts: inner.native_recovery_attempts,
+            probe_window: inner
+                .probe_window
+                .iter()
+                .map(|sample| ProbeWindowEntry {
+                    age_ms: elapsed_ms(now, sample.at),
+                    success: sample.success,
+                    reason: sample.reason.clone(),
+                    duration_ms: sample.duration_ms,
+                    bytes: sample.bytes,
+                })
+                .collect(),
+            incidents: inner
+                .incidents
+                .iter()
+                .map(|incident| IncidentSnapshot {
+                    age_ms: elapsed_ms(now, incident.at),
+                    generation: incident.generation,
+                    state: incident.state.clone(),
+                    reason: incident.reason.clone(),
+                    scheduler_lateness_ms: incident.scheduler_lateness_ms,
+                    probe_outcome: incident.probe_outcome.clone(),
+                    host_pressure: incident.host_pressure,
+                    recovery_action: incident.recovery_action.clone(),
+                    recovery_outcome: incident.recovery_outcome.clone(),
+                })
+                .collect(),
         }
     }
 
-    fn record(&self, generation: u64, update: HealthRecord) {
-        let mut inner = self.0.lock_recover();
+    fn set_resources(&self, generation: u64, resources: ResourceSample, scheduler: u64) {
+        let mut inner = self.inner.lock_recover();
         if inner.generation != generation {
             return;
         }
-        inner.state = update.state.into();
-        inner.reason = update.reason.map(str::to_owned);
-        inner.consecutive_failures = update.consecutive_failures;
+        update_pressure(&mut inner, resources, scheduler);
+        inner.scheduler_lateness_ms = scheduler;
+        inner.resources = resources;
+    }
+
+    fn record_probe(
+        &self,
+        generation: u64,
+        success: bool,
+        reason: Option<&str>,
+        duration_ms: u64,
+        bytes: u64,
+        resources: ResourceSample,
+        scheduler: u64,
+    ) {
+        let mut inner = self.inner.lock_recover();
+        if inner.generation != generation {
+            return;
+        }
+        update_pressure(&mut inner, resources, scheduler);
+        inner.scheduler_lateness_ms = scheduler;
+        inner.resources = resources;
         inner.last_probe_at = Some(Instant::now());
-        inner.last_probe_ms = update.probe_ms;
-        inner.scheduler_lateness_ms = update.scheduler_lateness_ms;
-        inner.host_pressure = update.resources.pressure;
-        inner.memory_load_percent = update.resources.memory_load_percent;
-        inner.available_memory_bytes = update.resources.available_memory_bytes;
+        inner.last_probe_ms = duration_ms;
+        if success {
+            inner.last_successful_probe_at = inner.last_probe_at;
+            inner.consecutive_successes = inner.consecutive_successes.saturating_add(1);
+            inner.consecutive_failures = 0;
+        } else {
+            inner.consecutive_failures = inner.consecutive_failures.saturating_add(1);
+            inner.consecutive_successes = 0;
+        }
+        if inner.probe_window.len() == PROBE_WINDOW_SIZE {
+            inner.probe_window.pop_front();
+        }
+        inner.probe_window.push_back(ProbeSample {
+            at: Instant::now(),
+            success,
+            reason: reason.map(str::to_owned),
+            duration_ms,
+            bytes,
+        });
+
+        let success_count = inner
+            .probe_window
+            .iter()
+            .filter(|sample| sample.success)
+            .count();
+        let failure_count = inner.probe_window.len().saturating_sub(success_count);
+        if success_count >= 2 {
+            inner.dataplane_state = "healthy".into();
+            inner.reason = None;
+        } else if failure_count >= 2 {
+            inner.dataplane_state = "failed".into();
+            inner.reason = reason.map(str::to_owned);
+        } else {
+            inner.dataplane_state = "suspect".into();
+            inner.reason = reason.map(str::to_owned);
+        }
+        inner.state = if inner.dataplane_state == "failed" {
+            "failed"
+        } else if inner.host_pressure {
+            "pressure"
+        } else {
+            inner.dataplane_state.as_str()
+        }
+        .into();
+        let incident_state = inner.state.clone();
+        let incident_reason = inner.reason.clone();
+        record_incident(
+            &mut inner,
+            generation,
+            &incident_state,
+            incident_reason.as_deref(),
+            scheduler,
+            Some(if success { "success" } else { "failure" }),
+            None,
+            None,
+        );
+    }
+
+    fn record_passive(
+        &self,
+        generation: u64,
+        local_ok: bool,
+        reason: Option<&str>,
+        duration_ms: u64,
+        resources: ResourceSample,
+        scheduler: u64,
+    ) {
+        let mut inner = self.inner.lock_recover();
+        if inner.generation != generation {
+            return;
+        }
+        update_pressure(&mut inner, resources, scheduler);
+        inner.scheduler_lateness_ms = scheduler;
+        inner.resources = resources;
+        inner.last_probe_at = Some(Instant::now());
+        inner.last_probe_ms = duration_ms;
+        inner.unmonitored_privacy_mode = true;
+        inner.monitoring_mode = "privacy_passive".into();
+        if local_ok {
+            inner.dataplane_state = "unmonitoredPrivacyMode".into();
+            inner.state = "unmonitoredPrivacyMode".into();
+            inner.reason = None;
+        } else {
+            inner.dataplane_state = "failed".into();
+            inner.state = "failed".into();
+            inner.reason = reason.map(str::to_owned);
+        }
+        let incident_state = inner.state.clone();
+        let incident_reason = inner.reason.clone();
+        record_incident(
+            &mut inner,
+            generation,
+            &incident_state,
+            incident_reason.as_deref(),
+            scheduler,
+            Some(if local_ok {
+                "passive_ok"
+            } else {
+                "passive_failure"
+            }),
+            None,
+            None,
+        );
+    }
+
+    fn recovery_decision(&self, now: Instant) -> RecoveryDecision {
+        let mut inner = self.inner.lock_recover();
+        prune_recovery_times(&mut inner, now);
+        if inner.native_recovery_state == "recovering" {
+            return RecoveryDecision::Busy;
+        }
+        if inner.native_recovery_times.len() >= NATIVE_RECOVERY_MAX {
+            inner.native_recovery_state = "exhausted".into();
+            return RecoveryDecision::Exhausted;
+        }
+        if let Some(last) = inner.native_recovery_times.back() {
+            if now.saturating_duration_since(*last) < NATIVE_RECOVERY_COOLDOWN {
+                inner.native_recovery_state = "cooldown".into();
+                return RecoveryDecision::Cooldown;
+            }
+        }
+        if inner.host_pressure {
+            if let Some(since) = inner.pressure_since {
+                if now.saturating_duration_since(since) < PRESSURE_RECOVERY_WAIT {
+                    inner.native_recovery_state = "pressure_wait".into();
+                    return RecoveryDecision::PressureWait;
+                }
+            } else {
+                inner.native_recovery_state = "pressure_wait".into();
+                return RecoveryDecision::PressureWait;
+            }
+        }
+        inner.native_recovery_times.push_back(now);
+        inner.native_recovery_attempts = inner.native_recovery_attempts.saturating_add(1);
+        inner.native_recovery_state = "recovering".into();
+        let generation = inner.generation;
+        let incident_reason = inner.reason.clone();
+        let scheduler_lateness = inner.scheduler_lateness_ms;
+        record_incident(
+            &mut inner,
+            generation,
+            "recovering",
+            incident_reason.as_deref(),
+            scheduler_lateness,
+            None,
+            Some("native_same_config_restart"),
+            Some("started"),
+        );
+        RecoveryDecision::Allowed
+    }
+
+    pub fn native_recovery_failed(&self, generation: u64, reason: &str) {
+        let mut inner = self.inner.lock_recover();
+        if inner.generation != generation {
+            return;
+        }
+        inner.native_recovery_state = if inner.native_recovery_times.len() >= NATIVE_RECOVERY_MAX {
+            "exhausted"
+        } else {
+            "cooldown"
+        }
+        .into();
+        inner.state = if inner.dataplane_state == "failed" {
+            "failed"
+        } else {
+            "cleanup_error"
+        }
+        .into();
+        inner.reason = Some(reason.to_string());
+        let incident_state = inner.state.clone();
+        let incident_reason = inner.reason.clone();
+        let scheduler_lateness = inner.scheduler_lateness_ms;
+        record_incident(
+            &mut inner,
+            generation,
+            &incident_state,
+            incident_reason.as_deref(),
+            scheduler_lateness,
+            None,
+            Some("native_same_config_restart"),
+            Some("failed_retryable"),
+        );
+    }
+
+    pub fn native_terminal_result(&self, generation: u64, cleanup_confirmed: bool) {
+        let mut inner = self.inner.lock_recover();
+        if inner.generation != generation {
+            return;
+        }
+        inner.native_recovery_state = if cleanup_confirmed {
+            "terminal"
+        } else {
+            "cleanup_error"
+        }
+        .into();
+        inner.state = if cleanup_confirmed {
+            "failed"
+        } else {
+            "cleanup_error"
+        }
+        .into();
+        inner.reason = Some(
+            if cleanup_confirmed {
+                "all_candidates_failed"
+            } else {
+                "cleanup_error"
+            }
+            .into(),
+        );
+        let incident_state = inner.state.clone();
+        let incident_reason = inner.reason.clone();
+        let scheduler_lateness = inner.scheduler_lateness_ms;
+        record_incident(
+            &mut inner,
+            generation,
+            &incident_state,
+            incident_reason.as_deref(),
+            scheduler_lateness,
+            None,
+            Some("fail_closed_cleanup"),
+            Some(if cleanup_confirmed {
+                "confirmed"
+            } else {
+                "failed_retryable"
+            }),
+        );
     }
 }
 
-#[derive(Clone, Copy, Default)]
-struct ResourceSample {
-    pressure: bool,
-    memory_load_percent: Option<u32>,
-    available_memory_bytes: Option<u64>,
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RecoveryDecision {
+    Allowed,
+    Busy,
+    Cooldown,
+    PressureWait,
+    Exhausted,
+}
+
+fn elapsed_ms(now: Instant, then: Instant) -> u64 {
+    now.saturating_duration_since(then)
+        .as_millis()
+        .min(u64::MAX as u128) as u64
+}
+
+fn prune_recovery_times(inner: &mut HealthInner, now: Instant) {
+    while inner
+        .native_recovery_times
+        .front()
+        .is_some_and(|at| now.saturating_duration_since(*at) >= NATIVE_RECOVERY_WINDOW)
+    {
+        inner.native_recovery_times.pop_front();
+    }
+}
+
+fn update_pressure(inner: &mut HealthInner, resources: ResourceSample, scheduler: u64) {
+    let entered = resources.pressure_entered(scheduler);
+    if !inner.host_pressure && entered {
+        inner.host_pressure = true;
+        inner.pressure_since = Some(Instant::now());
+        inner.pressure_exit_samples = 0;
+        inner.pressure_reason = Some(pressure_reason(resources, scheduler).into());
+        return;
+    }
+    if inner.host_pressure {
+        if resources.pressure_recovered(scheduler) {
+            inner.pressure_exit_samples = inner.pressure_exit_samples.saturating_add(1);
+            if inner.pressure_exit_samples >= PRESSURE_EXIT_SAMPLES {
+                inner.host_pressure = false;
+                inner.pressure_since = None;
+                inner.pressure_reason = None;
+                inner.pressure_exit_samples = 0;
+            }
+        } else {
+            inner.pressure_exit_samples = 0;
+            inner.pressure_reason = Some(pressure_reason(resources, scheduler).into());
+        }
+    }
+}
+
+fn pressure_reason(resources: ResourceSample, scheduler: u64) -> &'static str {
+    if scheduler >= PRESSURE_SCHEDULER_MS {
+        "scheduler_lateness"
+    } else if resources
+        .memory_load_percent
+        .is_some_and(|value| value >= PRESSURE_MEMORY_LOAD_PERCENT)
+    {
+        "memory_load"
+    } else if resources
+        .available_commit_bytes
+        .is_some_and(|value| value <= PRESSURE_AVAILABLE_COMMIT_BYTES)
+    {
+        "commit_available"
+    } else {
+        "physical_memory_available"
+    }
+}
+
+fn record_incident(
+    inner: &mut HealthInner,
+    generation: u64,
+    state: &str,
+    reason: Option<&str>,
+    scheduler_lateness_ms: u64,
+    probe_outcome: Option<&str>,
+    recovery_action: Option<&str>,
+    recovery_outcome: Option<&str>,
+) {
+    if inner.incidents.len() == INCIDENT_RING_SIZE {
+        inner.incidents.pop_front();
+    }
+    inner.incidents.push_back(Incident {
+        at: Instant::now(),
+        generation,
+        state: state.into(),
+        reason: reason.map(str::to_owned),
+        scheduler_lateness_ms,
+        probe_outcome: probe_outcome.map(str::to_owned),
+        host_pressure: inner.host_pressure,
+        recovery_action: recovery_action.map(str::to_owned),
+        recovery_outcome: recovery_outcome.map(str::to_owned),
+    });
 }
 
 #[cfg(target_os = "windows")]
@@ -176,13 +746,12 @@ fn resource_sample() -> ResourceSample {
     let Ok(()) = (unsafe { GlobalMemoryStatusEx(&mut status) }) else {
         return ResourceSample::default();
     };
-    let available = status.ullAvailPhys;
-    let load = status.dwMemoryLoad;
     ResourceSample {
-        pressure: load >= PRESSURE_MEMORY_LOAD_PERCENT
-            || available <= PRESSURE_AVAILABLE_MEMORY_BYTES,
-        memory_load_percent: Some(load),
-        available_memory_bytes: Some(available),
+        memory_load_percent: Some(status.dwMemoryLoad),
+        available_memory_bytes: Some(status.ullAvailPhys),
+        available_commit_bytes: Some(status.ullAvailPageFile),
+        available_pagefile_bytes: Some(status.ullAvailPageFile),
+        cpu_load_percent: None,
     }
 }
 
@@ -191,45 +760,81 @@ fn resource_sample() -> ResourceSample {
     ResourceSample::default()
 }
 
-fn probe_ok(result: &quality::ProbeResult) -> bool {
-    result.ok && !result.stalled && result.bytes >= PROBE_BYTES
-}
-
-fn probe_reason(result: &quality::ProbeResult) -> &'static str {
-    if result.stalled {
-        "dataplane_stalled"
-    } else if result.error.is_some() {
-        "dataplane_probe_failed"
-    } else {
-        "dataplane_probe_incomplete"
-    }
-}
-
 fn publish(app: &AppHandle, health: &DataplaneHealthState) {
     let _ = app.emit(HEALTH_EVENT, health.snapshot());
 }
 
-/// Starts one native monitor for one runtime generation.
-///
-/// The monitor intentionally does not perform recovery itself yet: recovery
-/// still needs frontend-owned profile/config selection. It does, however,
-/// keep the observation and pressure classification alive outside WebView
-/// timers and supplies the recovery controller with a trustworthy signal.
+fn local_reason(
+    status: &crate::vpn::NativeRuntimeStatus,
+    control_ok: bool,
+) -> Option<&'static str> {
+    if !status.running {
+        Some("unknown_datapath_failure")
+    } else if !status.xray_alive || !status.sidecars_alive {
+        Some("required_sidecar_failed")
+    } else if !status.clash_ready || !control_ok {
+        Some("control_api_unreachable")
+    } else {
+        None
+    }
+}
+
+async fn control_api_ok(port: u16) -> bool {
+    if port == 0 {
+        return false;
+    }
+    matches!(
+        tokio::time::timeout(
+            CONTROL_API_TIMEOUT,
+            crate::clash::clash_get_proxies_unchecked(port),
+        )
+        .await,
+        Ok(Ok(_))
+    )
+}
+
+/// Starts a monitor for one runtime generation. `probe_port=None` is still a
+/// valid runtime: the native status/control checks remain useful, but no
+/// arbitrary direct endpoint is introduced.
 pub fn start_dataplane_watchdog(
     app: AppHandle,
     health: Arc<DataplaneHealthState>,
     generation_token: Arc<AtomicU64>,
     generation: u64,
-    probe_port: u16,
+    probe_port: Option<u16>,
+    strict_privacy: bool,
+    preserve_recovery_budget: bool,
 ) {
     generation_token.store(generation, Ordering::SeqCst);
-    health.reset_active(generation);
+    health.reset_active_for_runtime(generation, strict_privacy, preserve_recovery_budget);
     publish(&app, &health);
+
+    // A deliberately tiny OS heartbeat. It measures scheduler lateness only;
+    // it does not perform IO, logging, HTTPS, frontend IPC or channel sends.
+    let heartbeat_token = generation_token.clone();
+    let heartbeat_health = health.clone();
+    std::thread::spawn(move || {
+        let mut scheduled = Instant::now() + HEARTBEAT_INTERVAL;
+        loop {
+            if heartbeat_token.load(Ordering::SeqCst) != generation {
+                break;
+            }
+            let now = Instant::now();
+            if now < scheduled {
+                std::thread::sleep(scheduled.duration_since(now));
+            }
+            if heartbeat_token.load(Ordering::SeqCst) != generation {
+                break;
+            }
+            let late = elapsed_ms(Instant::now(), scheduled);
+            heartbeat_health.set_heartbeat_lateness(generation, late);
+            scheduled += HEARTBEAT_INTERVAL;
+        }
+    });
 
     tauri::async_runtime::spawn(async move {
         tokio::time::sleep(INITIAL_DELAY).await;
         let mut next = Instant::now();
-        let mut failures = 0u32;
 
         loop {
             if generation_token.load(Ordering::SeqCst) != generation {
@@ -245,75 +850,151 @@ pub fn start_dataplane_watchdog(
             }
 
             let started = Instant::now();
-            let lateness = started
-                .saturating_duration_since(scheduled)
-                .as_millis()
-                .min(u64::MAX as u128) as u64;
+            let scheduler_lateness =
+                elapsed_ms(started, scheduled).max(health.heartbeat_lateness());
             let resources = resource_sample();
-            let result = quality::probe_quality_inner(
-                Some(probe_port),
-                WATCHDOG_ENDPOINTS.iter().map(|url| (*url).into()).collect(),
-                Some(PROBE_BYTES),
-                Some(PROBE_BUDGET_MS),
-            )
-            .await;
-            if generation_token.load(Ordering::SeqCst) != generation {
-                break;
-            }
-
-            let probe_ms = started.elapsed().as_millis().min(u64::MAX as u128) as u64;
-            let scheduler_pressure = lateness >= SCHEDULER_PRESSURE_MS;
-            let pressure = scheduler_pressure || resources.pressure;
-            let (state, reason, current_failures) = match result {
-                Ok(ref probe) if probe_ok(probe) && !pressure => {
-                    failures = 0;
-                    ("healthy", None, failures)
-                }
-                Ok(ref probe) if pressure => {
-                    failures = 0;
-                    ("pressure", Some("host_resource_pressure"), failures)
-                }
-                Err(_) if pressure => {
-                    failures = 0;
-                    ("pressure", Some("host_resource_pressure"), failures)
-                }
-                Ok(ref probe) => {
-                    failures = failures.saturating_add(1);
-                    let state = if failures >= FAILED_PROBES {
-                        "failed"
-                    } else {
-                        "suspect"
-                    };
-                    (state, Some(probe_reason(probe)), failures)
-                }
-                Err(_) => {
-                    failures = failures.saturating_add(1);
-                    let state = if failures >= FAILED_PROBES {
-                        "failed"
-                    } else {
-                        "suspect"
-                    };
-                    (state, Some("dataplane_probe_error"), failures)
-                }
+            health.set_resources(generation, resources, scheduler_lateness);
+            let status = crate::vpn::native_runtime_status(&app, generation);
+            let control_ok = if status.clash_ready {
+                control_api_ok(status.clash_port).await
+            } else {
+                false
             };
 
-            health.record(
-                generation,
-                HealthRecord {
-                    state,
+            if strict_privacy {
+                let reason = local_reason(&status, control_ok);
+                health.record_passive(
+                    generation,
+                    reason.is_none(),
                     reason,
-                    consecutive_failures: current_failures,
-                    probe_ms,
-                    scheduler_lateness_ms: lateness,
-                    resources: ResourceSample {
-                        pressure,
-                        ..resources
-                    },
-                },
-            );
+                    started.elapsed().as_millis() as u64,
+                    resources,
+                    scheduler_lateness,
+                );
+            } else if let Some(reason) = local_reason(&status, control_ok) {
+                health.record_probe(
+                    generation,
+                    false,
+                    Some(reason),
+                    started.elapsed().as_millis() as u64,
+                    0,
+                    resources,
+                    scheduler_lateness,
+                );
+            } else if probe_port.is_none() {
+                health.record_probe(
+                    generation,
+                    false,
+                    Some("probe_inbound_unreachable"),
+                    started.elapsed().as_millis() as u64,
+                    0,
+                    resources,
+                    scheduler_lateness,
+                );
+            } else {
+                let probe = tokio::time::timeout(
+                    HEALTH_PROBE_TIMEOUT,
+                    quality::probe_health_inner(probe_port),
+                )
+                .await;
+                match probe {
+                    Ok(Ok(result)) if result.ok => health.record_probe(
+                        generation,
+                        true,
+                        None,
+                        result.ms,
+                        result.bytes,
+                        resources,
+                        scheduler_lateness,
+                    ),
+                    Ok(Ok(result)) => health.record_probe(
+                        generation,
+                        false,
+                        Some(
+                            if result
+                                .error
+                                .as_deref()
+                                .is_some_and(|error| error.starts_with("HTTP"))
+                            {
+                                "probe_endpoint_failed"
+                            } else {
+                                "active_outbound_failed"
+                            },
+                        ),
+                        result.ms,
+                        result.bytes,
+                        resources,
+                        scheduler_lateness,
+                    ),
+                    Ok(Err(_)) | Err(_) => health.record_probe(
+                        generation,
+                        false,
+                        Some("probe_endpoint_failed"),
+                        started.elapsed().as_millis() as u64,
+                        0,
+                        resources,
+                        scheduler_lateness,
+                    ),
+                }
+            }
             publish(&app, &health);
+
+            let snapshot = health.snapshot();
+            let failed = snapshot.dataplane_state == "failed";
+            if failed && !strict_privacy {
+                match health.recovery_decision(Instant::now()) {
+                    RecoveryDecision::Allowed => {
+                        publish(&app, &health);
+                        let recovered =
+                            crate::vpn::native_recover_current_runtime(&app, generation).await;
+                        if recovered {
+                            // A successful same-config restart starts a new
+                            // monitor generation. The old coordinator exits.
+                            break;
+                        }
+                        health.native_recovery_failed(generation, "native_recovery_failed");
+                        publish(&app, &health);
+                    }
+                    RecoveryDecision::Exhausted => {
+                        let cleanup_confirmed =
+                            crate::vpn::native_terminal_fail_closed(&app, generation).await;
+                        health.native_terminal_result(generation, cleanup_confirmed);
+                        publish(&app, &health);
+                        break;
+                    }
+                    RecoveryDecision::Busy
+                    | RecoveryDecision::Cooldown
+                    | RecoveryDecision::PressureWait => {}
+                }
+            } else if failed && strict_privacy {
+                // Strict privacy never creates an external probe. Local/API
+                // failure is still recoverable natively, with the same budget.
+                match health.recovery_decision(Instant::now()) {
+                    RecoveryDecision::Allowed => {
+                        let recovered =
+                            crate::vpn::native_recover_current_runtime(&app, generation).await;
+                        if recovered {
+                            break;
+                        }
+                        health.native_recovery_failed(generation, "native_recovery_failed");
+                        publish(&app, &health);
+                    }
+                    RecoveryDecision::Exhausted => {
+                        let cleanup_confirmed =
+                            crate::vpn::native_terminal_fail_closed(&app, generation).await;
+                        health.native_terminal_result(generation, cleanup_confirmed);
+                        publish(&app, &health);
+                        break;
+                    }
+                    RecoveryDecision::Busy
+                    | RecoveryDecision::Cooldown
+                    | RecoveryDecision::PressureWait => {}
+                }
+            }
+
+            let snapshot = health.snapshot();
             next = Instant::now()
-                + if pressure {
+                + if snapshot.host_pressure {
                     PRESSURE_INTERVAL
                 } else {
                     HEALTH_INTERVAL
@@ -331,6 +1012,22 @@ pub fn stop_dataplane_watchdog(health: &DataplaneHealthState, generation_token: 
 mod tests {
     use super::*;
 
+    fn sample(health: &DataplaneHealthState, generation: u64, ok: bool) {
+        health.record_probe(
+            generation,
+            ok,
+            if ok {
+                None
+            } else {
+                Some("active_outbound_failed")
+            },
+            100,
+            if ok { 16 * 1024 } else { 0 },
+            ResourceSample::default(),
+            0,
+        );
+    }
+
     #[test]
     fn default_health_is_inactive() {
         let health = DataplaneHealthState::default();
@@ -347,20 +1044,84 @@ mod tests {
     }
 
     #[test]
+    fn rolling_window_marks_fsf_failed_and_two_successes_healthy() {
+        let health = DataplaneHealthState::default();
+        health.reset_active(42);
+        sample(&health, 42, false);
+        sample(&health, 42, true);
+        sample(&health, 42, false);
+        assert_eq!(health.snapshot().dataplane_state, "failed");
+        sample(&health, 42, true);
+        sample(&health, 42, true);
+        assert_eq!(health.snapshot().dataplane_state, "healthy");
+        assert_eq!(health.snapshot().probe_window.len(), PROBE_WINDOW_SIZE);
+    }
+
+    #[test]
+    fn pressure_does_not_erase_dataplane_failure() {
+        let health = DataplaneHealthState::default();
+        health.reset_active(42);
+        sample(&health, 42, false);
+        sample(&health, 42, false);
+        {
+            let mut inner = health.inner.lock_recover();
+            update_pressure(
+                &mut inner,
+                ResourceSample {
+                    memory_load_percent: Some(99),
+                    ..ResourceSample::default()
+                },
+                0,
+            );
+            inner.state = "failed".into();
+        }
+        let snapshot = health.snapshot();
+        assert_eq!(snapshot.dataplane_state, "failed");
+        assert!(snapshot.host_pressure);
+    }
+
+    #[test]
     fn stale_generation_cannot_overwrite_new_runtime_health() {
         let health = DataplaneHealthState::default();
         health.reset_active(42);
-        health.record(
-            41,
-            HealthRecord {
-                state: "failed",
-                reason: Some("stale"),
-                consecutive_failures: 2,
-                probe_ms: 100,
-                scheduler_lateness_ms: 0,
-                resources: ResourceSample::default(),
-            },
-        );
+        sample(&health, 41, false);
         assert_eq!(health.snapshot().state, "unknown");
+    }
+
+    #[test]
+    fn recovery_budget_distinguishes_cooldown_and_exhaustion() {
+        let health = DataplaneHealthState::default();
+        health.reset_active(42);
+        sample(&health, 42, false);
+        sample(&health, 42, false);
+        assert_eq!(
+            health.recovery_decision(Instant::now()),
+            RecoveryDecision::Allowed
+        );
+        assert_eq!(
+            health.recovery_decision(Instant::now()),
+            RecoveryDecision::Cooldown
+        );
+        {
+            let mut inner = health.inner.lock_recover();
+            inner.native_recovery_times.clear();
+            inner.native_recovery_times.extend(
+                (0..NATIVE_RECOVERY_MAX).map(|_| Instant::now() - NATIVE_RECOVERY_COOLDOWN),
+            );
+        }
+        assert_eq!(
+            health.recovery_decision(Instant::now()),
+            RecoveryDecision::Exhausted
+        );
+    }
+
+    #[test]
+    fn incident_ring_is_bounded() {
+        let health = DataplaneHealthState::default();
+        health.reset_active(42);
+        for _ in 0..(INCIDENT_RING_SIZE + 5) {
+            sample(&health, 42, false);
+        }
+        assert_eq!(health.snapshot().incidents.len(), INCIDENT_RING_SIZE);
     }
 }

--- a/src-tauri/src/killswitch.rs
+++ b/src-tauri/src/killswitch.rs
@@ -64,14 +64,10 @@ struct KillSwitchLease {
 #[derive(Default)]
 pub struct KillSwitchState(Mutex<Vec<KillSwitchLease>>);
 
-/// Включить или безопасно переармить kill switch. Новая WFP-сессия собирается
-/// транзакционно до закрытия предыдущей. Permit получают все движки Ninety,
-/// найденные рядом с нашим бинарём (Tauri кладёт сайдкары туда же): permit для
-/// не запущенного exe инертен, а пропущенный permit глушит протокол намертво —
-/// поэтому не гадаем, какие ноды в активном конфиге.
-#[tauri::command]
-pub fn killswitch_arm(
-    state: tauri::State<'_, KillSwitchState>,
+/// Внутренний вариант arm для нативного recovery. Он намеренно принимает тот
+/// же policy-контракт, что IPC-команда, чтобы recovery не обходил WFP-barrier.
+pub(crate) fn arm_policy(
+    state: &KillSwitchState,
     allow_lan: Option<bool>,
     tun_interface: Option<String>,
     strict_tunnel: Option<bool>,
@@ -128,6 +124,21 @@ pub fn killswitch_arm(
         let _ = (allow_lan, tun_interface, strict_tunnel);
         Err("kill switch доступен только на Windows".into())
     }
+}
+
+/// Включить или безопасно переармить kill switch. Новая WFP-сессия собирается
+/// транзакционно до закрытия предыдущей. Permit получают все движки Ninety,
+/// найденные рядом с нашим бинарём (Tauri кладёт сайдкары туда же): permit для
+/// не запущенного exe инертен, а пропущенный permit глушит протокол намертво —
+/// поэтому не гадаем, какие ноды в активном конфиге.
+#[tauri::command]
+pub fn killswitch_arm(
+    state: tauri::State<'_, KillSwitchState>,
+    allow_lan: Option<bool>,
+    tun_interface: Option<String>,
+    strict_tunnel: Option<bool>,
+) -> Result<(), String> {
+    arm_policy(&state, allow_lan, tun_interface, strict_tunnel)
 }
 
 /// Выключить kill switch (снять все фильтры). Идемпотентно.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ mod clash_stream;
 mod discord_cache;
 mod dnscheck;
 mod dpi;
+mod health;
 mod killswitch;
 mod netproc;
 mod protected_browser;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -812,6 +812,7 @@ pub fn run() {
             vpn::clear_log,
             vpn::singbox_log_path,
             vpn::open_log_dir,
+            quality::probe_health,
             subscription::fetch_subscription,
             clash::clash_get_proxies,
             clash::clash_get_connections,

--- a/src-tauri/src/quality.rs
+++ b/src-tauri/src/quality.rs
@@ -167,8 +167,7 @@ fn build_client(port: Option<u16>) -> Result<reqwest::Client, String> {
 /// Перебирает endpoints до первого, отдавшего тело; стримит до sample_bytes или
 /// budget_ms; по дороге ловит stall. Возвращает метрики первого успешного (или
 /// последнюю ошибку, если все легли).
-#[tauri::command]
-pub async fn probe_quality(
+pub(crate) async fn probe_quality_inner(
     port: Option<u16>,
     endpoints: Vec<String>,
     sample_bytes: Option<u64>,
@@ -191,6 +190,16 @@ pub async fn probe_quality(
         }
     }
     Ok(last_err)
+}
+
+#[tauri::command]
+pub async fn probe_quality(
+    port: Option<u16>,
+    endpoints: Vec<String>,
+    sample_bytes: Option<u64>,
+    budget_ms: Option<u64>,
+) -> Result<ProbeResult, String> {
+    probe_quality_inner(port, endpoints, sample_bytes, budget_ms).await
 }
 
 // Одна проба. Ok = тело пошло (метрики валидны, даже если потом stalled);

--- a/src-tauri/src/quality.rs
+++ b/src-tauri/src/quality.rs
@@ -34,11 +34,23 @@ const MAX_BUDGET_MS: u64 = 15_000;
 const MAX_ENDPOINTS: usize = 8;
 const MAX_REDIRECTS: usize = 3;
 const ALLOWED_QUALITY_HOSTS: &[&str] = &["speed.cloudflare.com"];
+const ALLOWED_HEALTH_HOSTS: &[&str] = &["speed.cloudflare.com", "www.gstatic.com"];
+const HEALTH_ENDPOINTS: &[&str] = &[
+    "https://speed.cloudflare.com/__down?bytes=16384",
+    "https://www.gstatic.com/generate_204",
+];
+const HEALTH_SAMPLE_BYTES: u64 = 16 * 1024;
+const HEALTH_BUDGET_MS: u64 = 6_000;
+const HEALTH_CHUNK_GAP_MS: u64 = 2_500;
 
-fn quality_host_allowed(host: &str) -> bool {
-    ALLOWED_QUALITY_HOSTS
+fn host_allowed(host: &str, allowlist: &[&str]) -> bool {
+    allowlist
         .iter()
         .any(|allowed| host.eq_ignore_ascii_case(allowed))
+}
+
+fn quality_host_allowed(host: &str) -> bool {
+    host_allowed(host, ALLOWED_QUALITY_HOSTS)
 }
 
 #[derive(Serialize)]
@@ -79,12 +91,20 @@ fn normalize_limits(sample_bytes: Option<u64>, budget_ms: Option<u64>) -> (u64, 
 }
 
 fn validate_endpoints(endpoints: Vec<String>) -> Result<Vec<String>, String> {
+    validate_endpoints_with_allowlist(endpoints, ALLOWED_QUALITY_HOSTS, "quality")
+}
+
+fn validate_endpoints_with_allowlist(
+    endpoints: Vec<String>,
+    allowlist: &[&str],
+    label: &str,
+) -> Result<Vec<String>, String> {
     if endpoints.is_empty() {
-        return Err("no endpoints".into());
+        return Err(format!("no {label} endpoints"));
     }
     if endpoints.len() > MAX_ENDPOINTS {
         return Err(format!(
-            "too many quality endpoints: maximum {MAX_ENDPOINTS}"
+            "too many {label} endpoints: maximum {MAX_ENDPOINTS}"
         ));
     }
 
@@ -93,21 +113,21 @@ fn validate_endpoints(endpoints: Vec<String>) -> Result<Vec<String>, String> {
         .map(|endpoint| {
             let endpoint = endpoint.trim();
             if endpoint.is_empty() {
-                return Err("quality endpoint is empty".into());
+                return Err(format!("{label} endpoint is empty"));
             }
             let parsed = reqwest::Url::parse(endpoint)
-                .map_err(|e| format!("invalid quality endpoint: {e}"))?;
+                .map_err(|e| format!("invalid {label} endpoint: {e}"))?;
             if parsed.scheme() != "https" || parsed.host_str().is_none() {
-                return Err("quality endpoint must be an absolute HTTPS URL".into());
+                return Err(format!("{label} endpoint must be an absolute HTTPS URL"));
             }
             if !parsed.username().is_empty() || parsed.password().is_some() {
-                return Err("quality endpoint credentials are not allowed".into());
+                return Err(format!("{label} endpoint credentials are not allowed"));
             }
             let host = parsed
                 .host_str()
-                .ok_or("quality endpoint host is missing")?;
-            if !quality_host_allowed(host) {
-                return Err(format!("quality endpoint host is not allowed: {host}"));
+                .ok_or_else(|| format!("{label} endpoint host is missing"))?;
+            if !host_allowed(host, allowlist) {
+                return Err(format!("{label} endpoint host is not allowed: {host}"));
             }
             Ok(endpoint.to_string())
         })
@@ -192,6 +212,49 @@ pub(crate) async fn probe_quality_inner(
     Ok(last_err)
 }
 
+/// Conservative dataplane liveness probe. This deliberately has its own
+/// thresholds and fixed endpoint allowlist: it must answer "does the route
+/// still work?", not "is the connection being throttled?". The second
+/// endpoint is used only when the first one fails, so the normal background
+/// traffic remains bounded.
+pub(crate) async fn probe_health_inner(port: Option<u16>) -> Result<ProbeResult, String> {
+    let endpoints = validate_endpoints_with_allowlist(
+        HEALTH_ENDPOINTS
+            .iter()
+            .map(|endpoint| (*endpoint).into())
+            .collect(),
+        ALLOWED_HEALTH_HOSTS,
+        "health",
+    )?;
+    let client = build_client(port)?;
+    let policy = ProbePolicy {
+        stall_before_bytes: HEALTH_SAMPLE_BYTES,
+        chunk_gap: Duration::from_millis(HEALTH_CHUNK_GAP_MS),
+        allow_empty_body: true,
+    };
+    let budget = Duration::from_millis(HEALTH_BUDGET_MS);
+    let overall = Instant::now();
+    let mut last = ProbeResult::fail(String::new(), 0, "no health endpoints".into());
+
+    for endpoint in &endpoints {
+        let Some(remaining) = budget.checked_sub(overall.elapsed()) else {
+            break;
+        };
+        match probe_one_with_policy(&client, endpoint, HEALTH_SAMPLE_BYTES, remaining, policy).await
+        {
+            Ok(result) if result.ok => return Ok(result),
+            Ok(result) => last = result,
+            Err(result) => last = result,
+        }
+    }
+    Ok(last)
+}
+
+#[tauri::command]
+pub async fn probe_health(port: Option<u16>) -> Result<ProbeResult, String> {
+    probe_health_inner(port).await
+}
+
 #[tauri::command]
 pub async fn probe_quality(
     port: Option<u16>,
@@ -209,6 +272,34 @@ async fn probe_one(
     endpoint: &str,
     sample_bytes: u64,
     budget: Duration,
+) -> Result<ProbeResult, ProbeResult> {
+    probe_one_with_policy(
+        client,
+        endpoint,
+        sample_bytes,
+        budget,
+        ProbePolicy {
+            stall_before_bytes: STALL_BYTES,
+            chunk_gap: Duration::from_millis(STALL_GAP_MS),
+            allow_empty_body: false,
+        },
+    )
+    .await
+}
+
+#[derive(Clone, Copy)]
+struct ProbePolicy {
+    stall_before_bytes: u64,
+    chunk_gap: Duration,
+    allow_empty_body: bool,
+}
+
+async fn probe_one_with_policy(
+    client: &reqwest::Client,
+    endpoint: &str,
+    sample_bytes: u64,
+    budget: Duration,
+    policy: ProbePolicy,
 ) -> Result<ProbeResult, ProbeResult> {
     let started = Instant::now();
 
@@ -241,6 +332,7 @@ async fn probe_one(
 
     // Стримим тело по чанкам. Каждый chunk() гейтим на STALL_GAP_MS — этот гейт
     // и есть детектор занавеса: до STALL_BYTES долгая пауза = троттл.
+    let status = resp.status();
     let mut resp = resp;
     let mut bytes: u64 = 0;
     let mut ttfb_ms: u64 = 0;
@@ -255,7 +347,7 @@ async fn probe_one(
         }
         let remaining = budget - elapsed;
         // Гейт чанка = min(остаток бюджета, окно stall).
-        let chunk_gate = remaining.min(Duration::from_millis(STALL_GAP_MS));
+        let chunk_gate = remaining.min(policy.chunk_gap);
 
         match tokio::time::timeout(chunk_gate, resp.chunk()).await {
             Ok(Ok(Some(chunk))) => {
@@ -283,7 +375,7 @@ async fn probe_one(
             }
             Err(_) => {
                 // Гейт сработал — пауза в потоке. До 64 КБ это подпись занавеса.
-                if bytes < STALL_BYTES {
+                if bytes < policy.stall_before_bytes {
                     stalled = true;
                 }
                 break;
@@ -295,6 +387,18 @@ async fn probe_one(
 
     // Тело так и не пошло — не успех, дайм шанс следующему endpoint.
     let Some(fb) = first_byte_at else {
+        if policy.allow_empty_body && status == reqwest::StatusCode::NO_CONTENT {
+            return Ok(ProbeResult {
+                ok: true,
+                goodput_bps: 0,
+                ttfb_ms: started.elapsed().as_millis() as u64,
+                bytes: 0,
+                ms,
+                stalled: false,
+                endpoint: endpoint.into(),
+                error: None,
+            });
+        }
         return Err(ProbeResult::fail(
             endpoint.into(),
             ms,

--- a/src-tauri/src/quality.rs
+++ b/src-tauri/src/quality.rs
@@ -49,10 +49,6 @@ fn host_allowed(host: &str, allowlist: &[&str]) -> bool {
         .any(|allowed| host.eq_ignore_ascii_case(allowed))
 }
 
-fn quality_host_allowed(host: &str) -> bool {
-    host_allowed(host, ALLOWED_QUALITY_HOSTS)
-}
-
 #[derive(Serialize)]
 pub struct ProbeResult {
     pub ok: bool,
@@ -473,10 +469,13 @@ mod tests {
 
     #[test]
     fn quality_host_allowlist_is_exact_and_case_insensitive() {
-        assert!(quality_host_allowed("speed.cloudflare.com"));
-        assert!(quality_host_allowed("SPEED.CLOUDFLARE.COM"));
-        assert!(!quality_host_allowed("localhost"));
-        assert!(!quality_host_allowed("speed.cloudflare.com.evil.example"));
+        assert!(host_allowed("speed.cloudflare.com", ALLOWED_QUALITY_HOSTS));
+        assert!(host_allowed("SPEED.CLOUDFLARE.COM", ALLOWED_QUALITY_HOSTS));
+        assert!(!host_allowed("localhost", ALLOWED_QUALITY_HOSTS));
+        assert!(!host_allowed(
+            "speed.cloudflare.com.evil.example",
+            ALLOWED_QUALITY_HOSTS
+        ));
     }
 
     #[test]

--- a/src-tauri/src/quality.rs
+++ b/src-tauri/src/quality.rs
@@ -479,6 +479,30 @@ mod tests {
     }
 
     #[test]
+    fn health_probe_has_independent_allowlist_and_liveness_thresholds() {
+        assert_eq!(HEALTH_SAMPLE_BYTES, 16 * 1024);
+        assert_eq!(HEALTH_BUDGET_MS, 6_000);
+        assert_eq!(HEALTH_CHUNK_GAP_MS, 2_500);
+        assert_ne!(HEALTH_SAMPLE_BYTES, STALL_BYTES);
+        assert_ne!(HEALTH_CHUNK_GAP_MS, STALL_GAP_MS);
+        assert!(validate_endpoints_with_allowlist(
+            HEALTH_ENDPOINTS
+                .iter()
+                .map(|endpoint| (*endpoint).into())
+                .collect(),
+            ALLOWED_HEALTH_HOSTS,
+            "health",
+        )
+        .is_ok());
+        assert!(validate_endpoints_with_allowlist(
+            vec!["https://example.com/health".into()],
+            ALLOWED_HEALTH_HOSTS,
+            "health",
+        )
+        .is_err());
+    }
+
+    #[test]
     fn redirects_stay_on_the_same_https_origin() {
         let initial = reqwest::Url::parse("https://example.com/probe").unwrap();
         assert!(redirect_target_allowed(

--- a/src-tauri/src/vpn.rs
+++ b/src-tauri/src/vpn.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashSet, VecDeque};
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use tokio::sync::Notify;
@@ -462,7 +462,7 @@ fn prune_sidecar_logs(dir: &std::path::Path, kind: SidecarLogKind, protected: &H
 //  - принудительно держим external_controller на 127.0.0.1 (даже если фронт
 //    зачем-то выставил 0.0.0.0) — управление ядром не должно торчать в сеть.
 // При невалидном JSON возвращаем как есть: пусть sing-box сам ругнётся.
-fn harden_config(raw: &str) -> String {
+fn harden_config(raw: &str, cache_path: Option<&Path>) -> String {
     let mut v: serde_json::Value = match serde_json::from_str(raw) {
         Ok(v) => v,
         Err(_) => return raw.to_string(),
@@ -487,7 +487,39 @@ fn harden_config(raw: &str) -> String {
             serde_json::Value::String(format!("127.0.0.1:{port}")),
         );
     }
+    if let Some(cache_path) = cache_path {
+        if let Some(root) = v.as_object_mut() {
+            let experimental = root
+                .entry("experimental")
+                .or_insert_with(|| serde_json::json!({}));
+            if !experimental.is_object() {
+                *experimental = serde_json::json!({});
+            }
+            let experimental = experimental
+                .as_object_mut()
+                .expect("experimental object was just initialized");
+            let cache_file = experimental
+                .entry("cache_file")
+                .or_insert_with(|| serde_json::json!({}));
+            if !cache_file.is_object() {
+                *cache_file = serde_json::json!({});
+            }
+            cache_file
+                .as_object_mut()
+                .expect("cache_file object was just initialized")
+                .insert(
+                    "path".into(),
+                    serde_json::Value::String(cache_path.to_string_lossy().into_owned()),
+                );
+        }
+    }
     serde_json::to_string(&v).unwrap_or_else(|_| raw.to_string())
+}
+
+fn singbox_cache_path(app: &AppHandle) -> Result<PathBuf, String> {
+    let dir = crate::app_paths::data_dir(app)?.join("singbox");
+    std::fs::create_dir_all(&dir).map_err(|e| format!("mkdir singbox data: {e}"))?;
+    Ok(dir.join("cache.db"))
 }
 
 fn config_path(app: &AppHandle) -> Result<PathBuf, String> {
@@ -1296,7 +1328,8 @@ async fn start_singbox_inner(
     };
     let _starting = StartingGuard(&state.starting);
     // Захардениваем конфиг (секрет clash-API + loopback) до записи/отправки.
-    let config_json = harden_config(&raw_config_json);
+    let cache_path = singbox_cache_path(&app)?;
+    let config_json = harden_config(&raw_config_json, Some(&cache_path));
     let (clash_port, runtime_ports) = runtime_ports_from_config(&config_json)?;
     let probe_port = probe_port_from_config(&config_json);
     *state.runtime_ports.lock_recover() = runtime_ports;
@@ -2216,7 +2249,7 @@ mod tests {
     #[test]
     fn harden_config_injects_secret_and_loopback() {
         let raw = r#"{"experimental":{"clash_api":{"external_controller":"0.0.0.0:9090"}}}"#;
-        let out = harden_config(raw);
+        let out = harden_config(raw, None);
         let v: serde_json::Value = serde_json::from_str(&out).unwrap();
         let api = &v["experimental"]["clash_api"];
         assert_eq!(api["external_controller"], "127.0.0.1:9090");
@@ -2225,8 +2258,20 @@ mod tests {
     }
 
     #[test]
+    fn harden_config_pins_cache_path_outside_the_working_directory() {
+        let raw = r#"{"experimental":{"cache_file":{"enabled":true,"store_rdrc":true}}}"#;
+        let cache_path = Path::new(r"C:\Users\test\AppData\Local\Ninety\data\singbox\cache.db");
+        let out = harden_config(raw, Some(cache_path));
+        let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(
+            v["experimental"]["cache_file"]["path"],
+            cache_path.to_string_lossy().as_ref()
+        );
+    }
+
+    #[test]
     fn harden_config_passes_invalid_json_through() {
-        assert_eq!(harden_config("not json"), "not json");
+        assert_eq!(harden_config("not json", None), "not json");
     }
 
     #[test]

--- a/src-tauri/src/vpn.rs
+++ b/src-tauri/src/vpn.rs
@@ -7,7 +7,7 @@ use tokio::sync::Notify;
 
 use crate::health;
 use crate::util::MutexExt;
-use tauri::{AppHandle, State};
+use tauri::{AppHandle, Manager, State};
 use tauri_plugin_shell::process::{CommandChild, CommandEvent};
 use tauri_plugin_shell::ShellExt;
 

--- a/src-tauri/src/vpn.rs
+++ b/src-tauri/src/vpn.rs
@@ -5,6 +5,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use tokio::sync::Notify;
 
+use crate::health;
 use crate::util::MutexExt;
 use tauri::{AppHandle, State};
 use tauri_plugin_shell::process::{CommandChild, CommandEvent};
@@ -248,6 +249,10 @@ pub struct SingboxState {
     pending_cleanup: Mutex<Option<PendingCleanup>>,
     live_processes: Arc<AtomicU64>,
     process_exit_notify: Arc<Notify>,
+    // Native dataplane watchdog. It is owned by the runtime state so a stale
+    // monitor can be cancelled before the next runtime generation starts.
+    dataplane_health: Arc<health::DataplaneHealthState>,
+    dataplane_generation: Arc<AtomicU64>,
 }
 
 #[derive(Clone)]
@@ -310,6 +315,8 @@ impl Default for SingboxState {
             pending_cleanup: Mutex::new(None),
             live_processes: Arc::new(AtomicU64::new(0)),
             process_exit_notify: Arc::new(Notify::new()),
+            dataplane_health: Arc::new(health::DataplaneHealthState::default()),
+            dataplane_generation: Arc::new(AtomicU64::new(0)),
         }
     }
 }
@@ -475,6 +482,34 @@ fn xray_log_path(app: &AppHandle) -> Option<PathBuf> {
     Some(dir.join("xray.log"))
 }
 
+// При высокой загрузке Windows не гарантирует, что userspace datapath будет
+// получать CPU вовремя. Поднимаем только критичные сетевые children до
+// ABOVE_NORMAL: HIGH/REALTIME намеренно не используем, чтобы не превращать
+// Ninety в источник starvation для всей системы.
+fn prioritize_datapath_process(pid: u32) {
+    #[cfg(target_os = "windows")]
+    {
+        use windows::Win32::Foundation::CloseHandle;
+        use windows::Win32::System::Threading::{
+            OpenProcess, SetPriorityClass, ABOVE_NORMAL_PRIORITY_CLASS, PROCESS_SET_INFORMATION,
+        };
+
+        unsafe {
+            match OpenProcess(PROCESS_SET_INFORMATION, false, pid) {
+                Ok(handle) => {
+                    if let Err(error) = SetPriorityClass(handle, ABOVE_NORMAL_PRIORITY_CLASS) {
+                        eprintln!("datapath priority failed for pid {pid}: {error}");
+                    }
+                    let _ = CloseHandle(handle);
+                }
+                Err(error) => eprintln!("datapath priority open failed for pid {pid}: {error}"),
+            }
+        }
+    }
+    #[cfg(not(target_os = "windows"))]
+    let _ = pid;
+}
+
 // Поднимает xray-core sidecar для xhttp-нод (two-core). Всегда user-level,
 // слушает 127.0.0.1; sing-box (свой child или сервис под LocalSystem) ходит
 // к нему через loopback socks-мосты из конфига. Spawn до sing-box.
@@ -499,6 +534,7 @@ async fn spawn_xray(
         .env("NO_COLOR", "1")
         .spawn()
         .map_err(|e| format!("spawn xray: {e}"))?;
+    prioritize_datapath_process(child.pid());
     *state.xray_child.lock_recover() = Some(child);
 
     let died_flag = state.xray_died.clone();
@@ -604,6 +640,7 @@ async fn spawn_sidecars(
             .env("NO_COLOR", "1")
             .spawn()
             .map_err(|e| format!("spawn {bin}: {e}"))?;
+        prioritize_datapath_process(child.pid());
         state.sidecars.lock_recover().push(child);
 
         let died_flag = state.sidecar_died.clone();
@@ -887,6 +924,25 @@ fn runtime_ports_from_config(raw: &str) -> Result<(u16, Vec<u16>), String> {
     Ok((clash, ports))
 }
 
+fn probe_port_from_config(raw: &str) -> Option<u16> {
+    let value: serde_json::Value = serde_json::from_str(raw).ok()?;
+    value
+        .get("inbounds")
+        .and_then(|v| v.as_array())
+        .and_then(|inbounds| {
+            inbounds.iter().find_map(|inbound| {
+                let tag = inbound.get("tag").and_then(|v| v.as_str())?;
+                if tag != "probe-in" && tag != "mixed-in" {
+                    return None;
+                }
+                inbound
+                    .get("listen_port")
+                    .and_then(|v| v.as_u64())
+                    .and_then(|port| u16::try_from(port).ok())
+            })
+        })
+}
+
 async fn wait_clash_ready(port: u16, state: &SingboxState, start_epoch: u64) -> Result<(), String> {
     let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(8);
     loop {
@@ -1157,6 +1213,7 @@ pub async fn start_singbox(
     // Захардениваем конфиг (секрет clash-API + loopback) до записи/отправки.
     let config_json = harden_config(&config_json);
     let (clash_port, runtime_ports) = runtime_ports_from_config(&config_json)?;
+    let probe_port = probe_port_from_config(&config_json);
     *state.runtime_ports.lock_recover() = runtime_ports;
     let sidecar_specs: Option<Vec<SidecarSpec>> = sidecars_json
         .as_ref()
@@ -1251,6 +1308,19 @@ pub async fn start_singbox(
         clash_port,
         clash_ready: true,
     });
+    if strict_privacy {
+        health::stop_dataplane_watchdog(&state.dataplane_health, &state.dataplane_generation);
+    } else if let Some(probe_port) = probe_port {
+        health::start_dataplane_watchdog(
+            app.clone(),
+            state.dataplane_health.clone(),
+            state.dataplane_generation.clone(),
+            process_generation,
+            probe_port,
+        );
+    } else {
+        health::stop_dataplane_watchdog(&state.dataplane_health, &state.dataplane_generation);
+    }
     Ok(runtime_snapshot_value(&state, false))
 }
 
@@ -1278,6 +1348,7 @@ async fn spawn_singbox_core(
         .env("NO_COLOR", "1")
         .spawn()
         .map_err(|e| format!("spawn sing-box: {e}"))?;
+    prioritize_datapath_process(child.pid());
 
     *state.child.lock_recover() = Some(child);
 
@@ -1459,6 +1530,7 @@ pub async fn stop_singbox(
     state: State<'_, SingboxState>,
 ) -> Result<StopResult, String> {
     let _stop = state.stop_lock.lock().await;
+    health::stop_dataplane_watchdog(&state.dataplane_health, &state.dataplane_generation);
     {
         let _gate = state.lifecycle_gate.lock_recover();
         state.stopping.store(true, Ordering::SeqCst);
@@ -1652,6 +1724,7 @@ pub struct HealthSnapshot {
     pub sidecar: &'static str,
     pub last_error: Option<String>,
     pub kill_switch_active: bool,
+    pub dataplane: health::DataplaneHealthSnapshot,
 }
 
 #[tauri::command]
@@ -1665,6 +1738,7 @@ pub fn health_snapshot(
         sidecar: compute_sidecar_status(&state),
         last_error: compute_last_error(&state),
         kill_switch_active: crate::killswitch::is_active(&kill_switch),
+        dataplane: state.dataplane_health.snapshot(),
     }
 }
 
@@ -1707,6 +1781,7 @@ pub fn vpn_last_error(state: State<'_, SingboxState>) -> Option<String> {
 }
 
 pub fn force_cleanup(app: &AppHandle, state: &SingboxState) {
+    health::stop_dataplane_watchdog(&state.dataplane_health, &state.dataplane_generation);
     if let Some(child) = state.child.lock_recover().take() {
         let _ = child.kill();
     }
@@ -1821,6 +1896,16 @@ mod tests {
     #[test]
     fn harden_config_passes_invalid_json_through() {
         assert_eq!(harden_config("not json"), "not json");
+    }
+
+    #[test]
+    fn probe_port_follows_the_runtime_probe_inbound() {
+        let tun = r#"{"inbounds":[{"type":"tun","tag":"tun-in"},{"type":"mixed","tag":"probe-in","listen_port":8787}]}"#;
+        let proxy = r#"{"inbounds":[{"type":"mixed","tag":"mixed-in","listen_port":9898}]}"#;
+        let unrelated = r#"{"inbounds":[{"type":"mixed","tag":"other","listen_port":7777}]}"#;
+        assert_eq!(probe_port_from_config(tun), Some(8787));
+        assert_eq!(probe_port_from_config(proxy), Some(9898));
+        assert_eq!(probe_port_from_config(unrelated), None);
     }
 
     #[test]

--- a/src-tauri/src/vpn.rs
+++ b/src-tauri/src/vpn.rs
@@ -1306,7 +1306,7 @@ async fn start_singbox_inner(
     if let Some(xj) = xray_json.as_ref().filter(|s| !s.trim().is_empty()) {
         if let Err(e) = spawn_xray(
             &app,
-            &state,
+            state,
             xj,
             logs_disabled,
             start_epoch,
@@ -1314,17 +1314,17 @@ async fn start_singbox_inner(
         )
         .await
         {
-            kill_xray(&state);
+            kill_xray(state);
             return Err(e);
         }
-        ensure_start_current(&state, start_epoch)?;
+        ensure_start_current(state, start_epoch)?;
     }
 
     // Sidecar-клиенты naive / trusttunnel (если такие ноды есть) — тоже ДО sing-box.
     if let Some(specs) = sidecar_specs.as_ref() {
         if let Err(e) = spawn_sidecars(
             &app,
-            &state,
+            state,
             specs,
             logs_disabled,
             start_epoch,
@@ -1332,11 +1332,11 @@ async fn start_singbox_inner(
         )
         .await
         {
-            kill_xray(&state);
-            kill_sidecars(&state);
+            kill_xray(state);
+            kill_sidecars(state);
             return Err(e);
         }
-        ensure_start_current(&state, start_epoch)?;
+        ensure_start_current(state, start_epoch)?;
     }
 
     // Режим (proxy/systemProxy/tun) больше не влияет на запуск ядра в Rust:
@@ -1351,7 +1351,7 @@ async fn start_singbox_inner(
     // xray_child.is_some() блокировал бы следующий старт до явного stop).
     if let Err(e) = spawn_singbox_core(
         &app,
-        &state,
+        state,
         &config_json,
         logs_disabled,
         start_epoch,
@@ -1363,18 +1363,18 @@ async fn start_singbox_inner(
         if let Some(child) = state.child.lock_recover().take() {
             let _ = child.kill();
         }
-        kill_xray(&state);
-        kill_sidecars(&state);
+        kill_xray(state);
+        kill_sidecars(state);
         return Err(e);
     }
-    ensure_start_current(&state, start_epoch)?;
+    ensure_start_current(state, start_epoch)?;
 
-    if let Err(e) = wait_clash_ready(clash_port, &state, start_epoch).await {
+    if let Err(e) = wait_clash_ready(clash_port, state, start_epoch).await {
         if let Some(child) = state.child.lock_recover().take() {
             let _ = child.kill();
         }
-        kill_xray(&state);
-        kill_sidecars(&state);
+        kill_xray(state);
+        kill_sidecars(state);
         *state.runtime_ports.lock_recover() = Vec::new();
         return Err(e);
     }
@@ -1414,7 +1414,7 @@ async fn start_singbox_inner(
     } else {
         health::stop_dataplane_watchdog(&state.dataplane_health, &state.dataplane_generation);
     }
-    Ok(runtime_snapshot_value(&state, false))
+    Ok(runtime_snapshot_value(state, false))
 }
 
 #[tauri::command]
@@ -1715,15 +1715,15 @@ async fn stop_singbox_inner(
     let proxy_ok = proxy::set_system_proxy(false, None, None).is_ok();
     let proxy_done_at = std::time::Instant::now();
     let (processes_exited, remaining_ports) =
-        wait_runtime_released(&state, &ports, &killed_processes).await;
+        wait_runtime_released(state, &ports, &killed_processes).await;
     let ports_released = remaining_ports.is_empty();
     let confirmed_at = std::time::Instant::now();
     let proxy_confirmed = !proxy_was_owned || proxy_ok;
     let cleanup_confirmed = processes_exited && ports_released && proxy_confirmed;
     if cleanup_confirmed {
-        purge_bridge_configs(&app);
-        purge_current_configs(&app);
-        clear_death_flags(&state);
+        purge_bridge_configs(app);
+        purge_current_configs(app);
+        clear_death_flags(state);
         *state.runtime.lock_recover() = None;
         *state.runtime_ports.lock_recover() = Vec::new();
         *state.pending_cleanup.lock_recover() = None;

--- a/src-tauri/src/vpn.rs
+++ b/src-tauri/src/vpn.rs
@@ -253,6 +253,15 @@ pub struct SingboxState {
     // monitor can be cancelled before the next runtime generation starts.
     dataplane_health: Arc<health::DataplaneHealthState>,
     dataplane_generation: Arc<AtomicU64>,
+    // Native recovery is a single owner. Frontend reconnects must not race a
+    // same-config stop/start in the short window between dependency teardown
+    // and readiness.
+    native_recovery_lock: tokio::sync::Mutex<()>,
+    native_recovery_active: AtomicBool,
+    // In-memory launch material is retained only for the current runtime. It
+    // enables a bounded native restart without asking WebView2 to rebuild or
+    // resend a profile containing credentials.
+    runtime_launch: Mutex<Option<RuntimeLaunchSpec>>,
 }
 
 #[derive(Clone)]
@@ -265,6 +274,21 @@ struct RuntimeRecord {
     pinned_node_tag: Option<String>,
     clash_port: u16,
     clash_ready: bool,
+}
+
+#[derive(Clone)]
+struct RuntimeLaunchSpec {
+    config_json: String,
+    mode: String,
+    xray_json: Option<String>,
+    sidecars_json: Option<String>,
+    logs_disabled: bool,
+    source_fingerprint: Option<String>,
+    config_hash: Option<String>,
+    strict_privacy: bool,
+    pinned_node_tag: Option<String>,
+    system_proxy_bypass_lan: bool,
+    kill_switch_expected: bool,
 }
 
 #[derive(Clone, Default)]
@@ -317,6 +341,9 @@ impl Default for SingboxState {
             process_exit_notify: Arc::new(Notify::new()),
             dataplane_health: Arc::new(health::DataplaneHealthState::default()),
             dataplane_generation: Arc::new(AtomicU64::new(0)),
+            native_recovery_lock: tokio::sync::Mutex::new(()),
+            native_recovery_active: AtomicBool::new(false),
+            runtime_launch: Mutex::new(None),
         }
     }
 }
@@ -883,6 +910,17 @@ pub struct RuntimeSnapshot {
     sidecars: serde_json::Value,
     system_proxy_ownership: &'static str,
     kill_switch_active: bool,
+    native_recovery_owner: String,
+    native_recovery_state: String,
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct NativeRuntimeStatus {
+    pub running: bool,
+    pub xray_alive: bool,
+    pub sidecars_alive: bool,
+    pub clash_ready: bool,
+    pub clash_port: u16,
 }
 
 fn runtime_ports_from_config(raw: &str) -> Result<(u16, Vec<u16>), String> {
@@ -1141,6 +1179,7 @@ async fn wait_runtime_released(
 fn runtime_snapshot_value(state: &SingboxState, kill_switch_active: bool) -> RuntimeSnapshot {
     let running = compute_singbox_running(state);
     let record = state.runtime.lock_recover().clone();
+    let health = state.dataplane_health.snapshot();
     RuntimeSnapshot {
         running,
         starting: state.starting.load(Ordering::SeqCst),
@@ -1159,32 +1198,73 @@ fn runtime_snapshot_value(state: &SingboxState, kill_switch_active: bool) -> Run
             "not_owned"
         },
         kill_switch_active,
+        native_recovery_owner: health.native_recovery_owner,
+        native_recovery_state: health.native_recovery_state,
     }
 }
 
-#[tauri::command]
-#[allow(clippy::too_many_arguments)] // Tauri IPC: именованные поля сохраняют совместимый wire contract.
-pub async fn start_singbox(
+pub(crate) fn native_runtime_status(
+    app: &AppHandle,
+    expected_generation: u64,
+) -> NativeRuntimeStatus {
+    let Some(state) = app.try_state::<SingboxState>() else {
+        return NativeRuntimeStatus::default();
+    };
+    let record = state.runtime.lock_recover().clone();
+    let process_generation = record
+        .as_ref()
+        .map(|runtime| runtime.process_generation)
+        .unwrap_or(0);
+    let generation_matches = expected_generation == 0 || process_generation == expected_generation;
+    NativeRuntimeStatus {
+        running: generation_matches && compute_singbox_running(&state),
+        xray_alive: if state.xray_child.lock_recover().is_none() {
+            true
+        } else {
+            state.xray_died.lock_recover().is_none()
+        },
+        sidecars_alive: if state.sidecars.lock_recover().is_empty() {
+            true
+        } else {
+            state.sidecar_died.lock_recover().is_none()
+        },
+        clash_ready: generation_matches
+            && record.as_ref().is_some_and(|runtime| runtime.clash_ready),
+        clash_port: record
+            .as_ref()
+            .map(|runtime| runtime.clash_port)
+            .unwrap_or(0),
+    }
+}
+
+async fn start_singbox_inner(
     app: AppHandle,
-    state: State<'_, SingboxState>,
-    config_json: String,
-    mode: String,
-    xray_json: Option<String>,
-    sidecars_json: Option<String>,
-    logs_disabled: Option<bool>,
-    source_fingerprint: Option<String>,
-    config_hash: Option<String>,
-    strict_privacy: Option<bool>,
-    pinned_node_tag: Option<String>,
+    state: &SingboxState,
+    spec: RuntimeLaunchSpec,
+    preserve_recovery_budget: bool,
 ) -> Result<RuntimeSnapshot, String> {
-    let logs_disabled = logs_disabled.unwrap_or(false);
-    let strict_privacy = strict_privacy.unwrap_or(false);
+    let RuntimeLaunchSpec {
+        config_json: raw_config_json,
+        mode,
+        xray_json,
+        sidecars_json,
+        logs_disabled,
+        source_fingerprint,
+        config_hash,
+        strict_privacy,
+        pinned_node_tag,
+        system_proxy_bypass_lan,
+        kill_switch_expected,
+    } = spec;
     let (start_epoch, process_generation) = {
         // Короткий синхронный gate делает старт/стоп линейными в точке смены
         // поколения; сам долгий запуск под ним не выполняется.
         let _gate = state.lifecycle_gate.lock_recover();
         if state.stopping.load(Ordering::SeqCst) {
             return Err("остановка ещё выполняется".into());
+        }
+        if state.native_recovery_active.load(Ordering::SeqCst) && !preserve_recovery_budget {
+            return Err("нативное восстановление ещё выполняется".into());
         }
         // Sentinel ДО child-проверки: второй конкурентный вызов отсекается,
         // пока первый ещё находится в await до публикации child.
@@ -1211,7 +1291,7 @@ pub async fn start_singbox(
     };
     let _starting = StartingGuard(&state.starting);
     // Захардениваем конфиг (секрет clash-API + loopback) до записи/отправки.
-    let config_json = harden_config(&config_json);
+    let config_json = harden_config(&raw_config_json);
     let (clash_port, runtime_ports) = runtime_ports_from_config(&config_json)?;
     let probe_port = probe_port_from_config(&config_json);
     *state.runtime_ports.lock_recover() = runtime_ports;
@@ -1300,28 +1380,79 @@ pub async fn start_singbox(
     }
     *state.runtime.lock_recover() = Some(RuntimeRecord {
         process_generation,
-        source_fingerprint,
-        config_hash,
-        mode,
+        source_fingerprint: source_fingerprint.clone(),
+        config_hash: config_hash.clone(),
+        mode: mode.clone(),
         strict_privacy,
-        pinned_node_tag,
+        pinned_node_tag: pinned_node_tag.clone(),
         clash_port,
         clash_ready: true,
     });
-    if strict_privacy {
-        health::stop_dataplane_watchdog(&state.dataplane_health, &state.dataplane_generation);
-    } else if let Some(probe_port) = probe_port {
+    *state.runtime_launch.lock_recover() = Some(RuntimeLaunchSpec {
+        config_json: config_json.clone(),
+        mode: mode.clone(),
+        xray_json: xray_json.clone(),
+        sidecars_json: sidecars_json.clone(),
+        logs_disabled,
+        source_fingerprint: source_fingerprint.clone(),
+        config_hash: config_hash.clone(),
+        strict_privacy,
+        pinned_node_tag: pinned_node_tag.clone(),
+        system_proxy_bypass_lan,
+        kill_switch_expected,
+    });
+    if strict_privacy || probe_port.is_some() {
         health::start_dataplane_watchdog(
             app.clone(),
             state.dataplane_health.clone(),
             state.dataplane_generation.clone(),
             process_generation,
             probe_port,
+            strict_privacy,
+            preserve_recovery_budget,
         );
     } else {
         health::stop_dataplane_watchdog(&state.dataplane_health, &state.dataplane_generation);
     }
     Ok(runtime_snapshot_value(&state, false))
+}
+
+#[tauri::command]
+#[allow(clippy::too_many_arguments)] // Tauri IPC: именованные поля сохраняют совместимый wire contract.
+pub async fn start_singbox(
+    app: AppHandle,
+    state: State<'_, SingboxState>,
+    config_json: String,
+    mode: String,
+    xray_json: Option<String>,
+    sidecars_json: Option<String>,
+    logs_disabled: Option<bool>,
+    source_fingerprint: Option<String>,
+    config_hash: Option<String>,
+    strict_privacy: Option<bool>,
+    pinned_node_tag: Option<String>,
+    system_proxy_bypass_lan: Option<bool>,
+    kill_switch_expected: Option<bool>,
+) -> Result<RuntimeSnapshot, String> {
+    start_singbox_inner(
+        app,
+        &state,
+        RuntimeLaunchSpec {
+            config_json,
+            mode,
+            xray_json,
+            sidecars_json,
+            logs_disabled: logs_disabled.unwrap_or(false),
+            source_fingerprint,
+            config_hash,
+            strict_privacy: strict_privacy.unwrap_or(false),
+            pinned_node_tag,
+            system_proxy_bypass_lan: system_proxy_bypass_lan.unwrap_or(true),
+            kill_switch_expected: kill_switch_expected.unwrap_or(false),
+        },
+        false,
+    )
+    .await
 }
 
 // Запись конфига + спавн sing-box + fail-fast-окно. Вынесено из start_singbox,
@@ -1524,13 +1655,16 @@ struct StopTimings {
     total_ms: u64,
 }
 
-#[tauri::command]
-pub async fn stop_singbox(
-    app: AppHandle,
-    state: State<'_, SingboxState>,
+async fn stop_singbox_inner(
+    app: &AppHandle,
+    state: &SingboxState,
+    stop_watchdog: bool,
+    retain_launch: bool,
 ) -> Result<StopResult, String> {
     let _stop = state.stop_lock.lock().await;
-    health::stop_dataplane_watchdog(&state.dataplane_health, &state.dataplane_generation);
+    if stop_watchdog {
+        health::stop_dataplane_watchdog(&state.dataplane_health, &state.dataplane_generation);
+    }
     {
         let _gate = state.lifecycle_gate.lock_recover();
         state.stopping.store(true, Ordering::SeqCst);
@@ -1593,6 +1727,9 @@ pub async fn stop_singbox(
         *state.runtime.lock_recover() = None;
         *state.runtime_ports.lock_recover() = Vec::new();
         *state.pending_cleanup.lock_recover() = None;
+        if !retain_launch {
+            *state.runtime_launch.lock_recover() = None;
+        }
     } else {
         *state.pending_cleanup.lock_recover() = Some(PendingCleanup {
             processes: unresolved_processes(&killed_processes),
@@ -1641,6 +1778,171 @@ pub async fn stop_singbox(
             total_ms: started_at.elapsed().as_millis() as u64,
         },
     })
+}
+
+#[tauri::command]
+pub async fn stop_singbox(
+    app: AppHandle,
+    state: State<'_, SingboxState>,
+) -> Result<StopResult, String> {
+    if state.native_recovery_active.load(Ordering::SeqCst) {
+        return Err("нативное восстановление ещё выполняется".into());
+    }
+    stop_singbox_inner(&app, &state, true, false).await
+}
+
+struct NativeRecoveryOwner<'a>(&'a AtomicBool);
+
+impl Drop for NativeRecoveryOwner<'_> {
+    fn drop(&mut self) {
+        self.0.store(false, Ordering::SeqCst);
+    }
+}
+
+fn native_recovery_result_is_ready(result: &StopResult) -> bool {
+    result.processes_exited && result.ports_released && result.system_proxy != "failed"
+}
+
+async fn native_reapply_runtime_policy(
+    app: &AppHandle,
+    state: &SingboxState,
+    spec: &RuntimeLaunchSpec,
+    snapshot: &RuntimeSnapshot,
+) -> Result<(), String> {
+    if spec.mode == "systemProxy" {
+        let port = probe_port_from_config(&spec.config_json)
+            .ok_or_else(|| "после native recovery не найден mixed-in порт".to_string())?;
+        let host_port = format!("127.0.0.1:{port}");
+        proxy::set_system_proxy(true, Some(&host_port), Some(spec.system_proxy_bypass_lan))?;
+        if !proxy::system_proxy_owned() {
+            return Err("system proxy ownership не подтверждена после native recovery".into());
+        }
+    }
+
+    if spec.kill_switch_expected {
+        let Some(kill_switch) = app.try_state::<crate::killswitch::KillSwitchState>() else {
+            return Err("kill switch state недоступен для native recovery".into());
+        };
+        crate::killswitch::arm_policy(
+            &kill_switch,
+            Some(if spec.strict_privacy {
+                false
+            } else {
+                spec.system_proxy_bypass_lan
+            }),
+            spec.strict_privacy.then(|| "ninety-tun".to_string()),
+            Some(spec.strict_privacy),
+        )?;
+        if !crate::killswitch::is_active(&kill_switch) {
+            return Err("kill switch readiness не подтверждена после native recovery".into());
+        }
+    }
+
+    let current = native_runtime_status(app, snapshot.process_generation);
+    if !current.running || !current.clash_ready {
+        return Err("native recovery runtime не прошёл readiness".into());
+    }
+    let _ = state;
+    Ok(())
+}
+
+/// Controlled same-config restart. This path never asks WebView2 for a new
+/// profile and never chooses a different node. It is guarded by both an async
+/// owner lock and a runtime-level active flag, so frontend stop/reconnect calls
+/// cannot interleave with the dependency graph restart.
+pub(crate) async fn native_recover_current_runtime(
+    app: &AppHandle,
+    expected_generation: u64,
+) -> bool {
+    let Some(state) = app.try_state::<SingboxState>() else {
+        return false;
+    };
+    let Ok(_owner_lock) = state.native_recovery_lock.try_lock() else {
+        return false;
+    };
+    if state.native_recovery_active.swap(true, Ordering::SeqCst) {
+        return false;
+    }
+    let _owner = NativeRecoveryOwner(&state.native_recovery_active);
+
+    let Some(spec) = state.runtime_launch.lock_recover().clone() else {
+        return false;
+    };
+    let Some(runtime) = state.runtime.lock_recover().clone() else {
+        return false;
+    };
+    if runtime.process_generation != expected_generation
+        || !compute_singbox_running(&state)
+        || state.starting.load(Ordering::SeqCst)
+        || state.stopping.load(Ordering::SeqCst)
+    {
+        return false;
+    }
+
+    let Ok(stopped) = stop_singbox_inner(app, &state, false, true).await else {
+        return false;
+    };
+    if !native_recovery_result_is_ready(&stopped) {
+        return false;
+    }
+
+    let Ok(snapshot) = start_singbox_inner(app.clone(), &state, spec.clone(), true).await else {
+        return false;
+    };
+    if let Err(error) = native_reapply_runtime_policy(app, &state, &spec, &snapshot).await {
+        let _ = stop_singbox_inner(app, &state, false, false).await;
+        let _ = error;
+        return false;
+    }
+    true
+}
+
+/// Last-resort native fail-closed cleanup after the bounded same-config budget
+/// is exhausted. WFP is armed/re-armed before the dependency stop whenever the
+/// saved runtime policy requires it; a failed cleanup is reported as retryable
+/// and never latched as a confirmed terminal state.
+pub(crate) async fn native_terminal_fail_closed(app: &AppHandle, expected_generation: u64) -> bool {
+    let Some(state) = app.try_state::<SingboxState>() else {
+        return false;
+    };
+    let Ok(_owner_lock) = state.native_recovery_lock.try_lock() else {
+        return false;
+    };
+    if state.native_recovery_active.swap(true, Ordering::SeqCst) {
+        return false;
+    }
+    let _owner = NativeRecoveryOwner(&state.native_recovery_active);
+    let spec = state.runtime_launch.lock_recover().clone();
+    if let Some(runtime) = state.runtime.lock_recover().clone() {
+        if runtime.process_generation != expected_generation {
+            return false;
+        }
+    }
+
+    if let Some(spec) = spec.as_ref().filter(|spec| spec.kill_switch_expected) {
+        let Some(kill_switch) = app.try_state::<crate::killswitch::KillSwitchState>() else {
+            return false;
+        };
+        if crate::killswitch::arm_policy(
+            &kill_switch,
+            Some(if spec.strict_privacy {
+                false
+            } else {
+                spec.system_proxy_bypass_lan
+            }),
+            spec.strict_privacy.then(|| "ninety-tun".to_string()),
+            Some(spec.strict_privacy),
+        )
+        .is_err()
+        {
+            return false;
+        }
+    }
+
+    let Ok(result) = stop_singbox_inner(app, &state, false, false).await else {
+        return false;
+    };
+    native_recovery_result_is_ready(&result)
 }
 
 // Внутренние вычисления статусов — переиспользуются одиночными командами и

--- a/src-tauri/src/vpn.rs
+++ b/src-tauri/src/vpn.rs
@@ -258,6 +258,10 @@ pub struct SingboxState {
     // and readiness.
     native_recovery_lock: tokio::sync::Mutex<()>,
     native_recovery_active: AtomicBool,
+    // A manual disconnect may arrive while native recovery owns the lifecycle.
+    // It cancels the restart before the next generation is published; the
+    // caller then acquires the same owner lock and performs the verified stop.
+    native_recovery_cancelled: AtomicBool,
     // In-memory launch material is retained only for the current runtime. It
     // enables a bounded native restart without asking WebView2 to rebuild or
     // resend a profile containing credentials.
@@ -343,6 +347,7 @@ impl Default for SingboxState {
             dataplane_generation: Arc::new(AtomicU64::new(0)),
             native_recovery_lock: tokio::sync::Mutex::new(()),
             native_recovery_active: AtomicBool::new(false),
+            native_recovery_cancelled: AtomicBool::new(false),
             runtime_launch: Mutex::new(None),
         }
     }
@@ -1785,10 +1790,19 @@ pub async fn stop_singbox(
     app: AppHandle,
     state: State<'_, SingboxState>,
 ) -> Result<StopResult, String> {
-    if state.native_recovery_active.load(Ordering::SeqCst) {
-        return Err("нативное восстановление ещё выполняется".into());
-    }
-    stop_singbox_inner(&app, &state, true, false).await
+    // Manual disconnect wins over native recovery. Set the cancellation bit
+    // before waiting for the owner lock, then perform the same verified stop
+    // after the native action has released it. This avoids both a restart after
+    // the user's disconnect and a parallel cleanup of the dependency graph.
+    state
+        .native_recovery_cancelled
+        .store(true, Ordering::SeqCst);
+    let _recovery_lock = state.native_recovery_lock.lock().await;
+    let result = stop_singbox_inner(&app, &state, true, false).await;
+    state
+        .native_recovery_cancelled
+        .store(false, Ordering::SeqCst);
+    result
 }
 
 struct NativeRecoveryOwner<'a>(&'a AtomicBool);
@@ -1803,9 +1817,31 @@ fn native_recovery_result_is_ready(result: &StopResult) -> bool {
     result.processes_exited && result.ports_released && result.system_proxy != "failed"
 }
 
+fn native_rearm_saved_kill_switch(app: &AppHandle, spec: &RuntimeLaunchSpec) -> Result<(), String> {
+    if !spec.kill_switch_expected {
+        return Ok(());
+    }
+    let Some(kill_switch) = app.try_state::<crate::killswitch::KillSwitchState>() else {
+        return Err("kill switch state недоступен для native recovery".into());
+    };
+    crate::killswitch::arm_policy(
+        &kill_switch,
+        Some(if spec.strict_privacy {
+            false
+        } else {
+            spec.system_proxy_bypass_lan
+        }),
+        spec.strict_privacy.then(|| "ninety-tun".to_string()),
+        Some(spec.strict_privacy),
+    )?;
+    if !crate::killswitch::is_active(&kill_switch) {
+        return Err("kill switch readiness не подтверждена после native recovery".into());
+    }
+    Ok(())
+}
+
 async fn native_reapply_runtime_policy(
     app: &AppHandle,
-    state: &SingboxState,
     spec: &RuntimeLaunchSpec,
     snapshot: &RuntimeSnapshot,
 ) -> Result<(), String> {
@@ -1819,30 +1855,12 @@ async fn native_reapply_runtime_policy(
         }
     }
 
-    if spec.kill_switch_expected {
-        let Some(kill_switch) = app.try_state::<crate::killswitch::KillSwitchState>() else {
-            return Err("kill switch state недоступен для native recovery".into());
-        };
-        crate::killswitch::arm_policy(
-            &kill_switch,
-            Some(if spec.strict_privacy {
-                false
-            } else {
-                spec.system_proxy_bypass_lan
-            }),
-            spec.strict_privacy.then(|| "ninety-tun".to_string()),
-            Some(spec.strict_privacy),
-        )?;
-        if !crate::killswitch::is_active(&kill_switch) {
-            return Err("kill switch readiness не подтверждена после native recovery".into());
-        }
-    }
+    native_rearm_saved_kill_switch(app, spec)?;
 
     let current = native_runtime_status(app, snapshot.process_generation);
     if !current.running || !current.clash_ready {
         return Err("native recovery runtime не прошёл readiness".into());
     }
-    let _ = state;
     Ok(())
 }
 
@@ -1860,6 +1878,12 @@ pub(crate) async fn native_recover_current_runtime(
     let Ok(_owner_lock) = state.native_recovery_lock.try_lock() else {
         return false;
     };
+    if state.native_recovery_cancelled.load(Ordering::SeqCst) {
+        return false;
+    }
+    state
+        .native_recovery_cancelled
+        .store(false, Ordering::SeqCst);
     if state.native_recovery_active.swap(true, Ordering::SeqCst) {
         return false;
     }
@@ -1879,19 +1903,35 @@ pub(crate) async fn native_recover_current_runtime(
         return false;
     }
 
+    if state.native_recovery_cancelled.load(Ordering::SeqCst)
+        || native_rearm_saved_kill_switch(app, &spec).is_err()
+    {
+        return false;
+    }
+
     let Ok(stopped) = stop_singbox_inner(app, &state, false, true).await else {
         return false;
     };
-    if !native_recovery_result_is_ready(&stopped) {
+    if !native_recovery_result_is_ready(&stopped)
+        || state.native_recovery_cancelled.load(Ordering::SeqCst)
+    {
         return false;
     }
 
     let Ok(snapshot) = start_singbox_inner(app.clone(), &state, spec.clone(), true).await else {
         return false;
     };
-    if let Err(error) = native_reapply_runtime_policy(app, &state, &spec, &snapshot).await {
+    if state.native_recovery_cancelled.load(Ordering::SeqCst) {
+        let _ = stop_singbox_inner(app, &state, false, false).await;
+        return false;
+    }
+    if let Err(error) = native_reapply_runtime_policy(app, &spec, &snapshot).await {
         let _ = stop_singbox_inner(app, &state, false, false).await;
         let _ = error;
+        return false;
+    }
+    if state.native_recovery_cancelled.load(Ordering::SeqCst) {
+        let _ = stop_singbox_inner(app, &state, false, false).await;
         return false;
     }
     true
@@ -1908,6 +1948,9 @@ pub(crate) async fn native_terminal_fail_closed(app: &AppHandle, expected_genera
     let Ok(_owner_lock) = state.native_recovery_lock.try_lock() else {
         return false;
     };
+    if state.native_recovery_cancelled.load(Ordering::SeqCst) {
+        return false;
+    }
     if state.native_recovery_active.swap(true, Ordering::SeqCst) {
         return false;
     }
@@ -1919,22 +1962,8 @@ pub(crate) async fn native_terminal_fail_closed(app: &AppHandle, expected_genera
         }
     }
 
-    if let Some(spec) = spec.as_ref().filter(|spec| spec.kill_switch_expected) {
-        let Some(kill_switch) = app.try_state::<crate::killswitch::KillSwitchState>() else {
-            return false;
-        };
-        if crate::killswitch::arm_policy(
-            &kill_switch,
-            Some(if spec.strict_privacy {
-                false
-            } else {
-                spec.system_proxy_bypass_lan
-            }),
-            spec.strict_privacy.then(|| "ninety-tun".to_string()),
-            Some(spec.strict_privacy),
-        )
-        .is_err()
-        {
+    if let Some(spec) = spec.as_ref() {
+        if native_rearm_saved_kill_switch(app, spec).is_err() {
             return false;
         }
     }

--- a/src/lib/health-watchdog.js
+++ b/src/lib/health-watchdog.js
@@ -157,8 +157,11 @@ export function initHealthWatchdog({
         .includes(dataplane.nativeRecoveryState);
     if (nativeOwner) {
       if (dataplane.nativeRecoveryState === "terminal" && active(run) && !dataplaneTerminal) {
-        const confirmed = await onDataplaneFailed(dataplane);
-        if (confirmed === true) dataplaneTerminal = true;
+        // The native monitor normally performs this action itself. If a
+        // terminal snapshot reaches WebView2, keep the same confirmation,
+        // retry delay, and bounded budget instead of calling cleanup on every
+        // five-second health tick after a failed shutdown.
+        await failClosedAfterExhaustion(run, dataplane);
       }
       if (!dataplaneEmergencyPaused) {
         dataplaneEmergencyPaused = true;

--- a/src/lib/health-watchdog.js
+++ b/src/lib/health-watchdog.js
@@ -51,6 +51,7 @@ export function initHealthWatchdog({
   toast: toastFn = toast,
   notify: notifyFn = notify,
   t: tr = t,
+  now: nowFn = Date.now,
   setInterval: setIntervalFn = setInterval,
   clearInterval: clearIntervalFn = clearInterval,
 }) {
@@ -63,53 +64,124 @@ export function initHealthWatchdog({
   let dataplaneRecoveryBusy = false;
   let dataplaneRecoveryGraceUntil = 0;
   let dataplaneTerminal = false;
+  let dataplaneTerminalBusy = false;
+  let dataplaneTerminalRetryAt = 0;
+  let dataplaneTerminalAttempts = [];
+  let dataplaneEmergencyPaused = false;
 
   const current = (run) => run === generation && !isUpdateInstalling();
   const active = (run) => current(run) && getState() === "connected";
 
   function bridgeReconnectAllowed() {
-    const cut = Date.now() - BRIDGE_RECONNECT_WINDOW_MS;
+    const cut = nowFn() - BRIDGE_RECONNECT_WINDOW_MS;
     bridgeReconnects = bridgeReconnects.filter((ts) => ts > cut);
     if (bridgeReconnects.length >= BRIDGE_RECONNECT_MAX) return false;
-    bridgeReconnects.push(Date.now());
+    bridgeReconnects.push(nowFn());
     return true;
   }
 
-  function dataplaneRecoveryAllowed() {
-    const now = Date.now();
+  function dataplaneRecoveryDecision() {
+    const now = nowFn();
     const cut = now - DATAPLANE_RECOVERY_WINDOW_MS;
     dataplaneRecoveries = dataplaneRecoveries.filter((ts) => ts > cut);
-    const last = dataplaneRecoveries.at(-1) || 0;
-    return dataplaneRecoveries.length < DATAPLANE_RECOVERY_MAX
-      && now - last >= DATAPLANE_RECOVERY_COOLDOWN_MS;
+    const last = dataplaneRecoveries.at(-1);
+    if (dataplaneRecoveries.length >= DATAPLANE_RECOVERY_MAX) {
+      return { state: "exhausted", attempts: dataplaneRecoveries.length, retryAt: null };
+    }
+    if (last !== undefined && now - last < DATAPLANE_RECOVERY_COOLDOWN_MS) {
+      return {
+        state: "cooldown",
+        attempts: dataplaneRecoveries.length,
+        retryAt: last + DATAPLANE_RECOVERY_COOLDOWN_MS,
+      };
+    }
+    return { state: "allowed", attempts: dataplaneRecoveries.length, retryAt: null };
+  }
+
+  function resetEmergencyPause() {
+    if (!dataplaneEmergencyPaused) return;
+    dataplaneEmergencyPaused = false;
+    getQualityEngine()?.resumeAfterEmergency?.();
+  }
+
+  async function failClosedAfterExhaustion(run, dataplane) {
+    const now = nowFn();
+    const cut = now - DATAPLANE_RECOVERY_WINDOW_MS;
+    dataplaneTerminalAttempts = dataplaneTerminalAttempts.filter((ts) => ts > cut);
+    if (dataplaneTerminal || dataplaneTerminalBusy
+      || now < dataplaneTerminalRetryAt
+      || dataplaneTerminalAttempts.length >= DATAPLANE_RECOVERY_MAX
+      || !active(run)) return true;
+
+    dataplaneTerminalAttempts.push(now);
+    dataplaneTerminalBusy = true;
+    try {
+      // A failed shutdown is not terminal: cleanup_error remains retryable, but
+      // retries are bounded and delayed so a stuck process cannot cause a loop.
+      const confirmed = await onDataplaneFailed(dataplane);
+      if (confirmed === true) {
+        dataplaneTerminal = true;
+        dataplaneTerminalRetryAt = 0;
+      } else {
+        dataplaneTerminalRetryAt = nowFn() + DATAPLANE_RECOVERY_COOLDOWN_MS;
+      }
+    } finally {
+      dataplaneTerminalBusy = false;
+    }
+    return true;
   }
 
   async function handleDataplaneHealth(run, snap) {
     const dataplane = snap?.dataplane;
     if (!dataplane) return false;
     if (dataplane.state === "inactive") return false;
+    const dataplaneState = dataplane.dataplaneState || dataplane.state;
     const pressure = dataplane.hostPressure === true || dataplane.state === "pressure";
     getQualityEngine()?.setHostPressure?.(pressure);
 
-    if (dataplane.state === "healthy") {
+    if (dataplaneState === "healthy" || dataplaneState === "unmonitoredPrivacyMode") {
       dataplaneRecoveryGraceUntil = 0;
       dataplaneTerminal = false;
+      dataplaneTerminalRetryAt = 0;
+      dataplaneTerminalAttempts = [];
+      resetEmergencyPause();
       return false;
     }
-    if (pressure || dataplane.state !== "failed") return true;
-    if (!active(run)) return true;
-    if (Date.now() < dataplaneRecoveryGraceUntil || dataplaneRecoveryBusy) return true;
+    if (dataplaneState !== "failed") return true;
 
-    if (!dataplaneRecoveryAllowed()) {
-      if (!dataplaneTerminal) {
-        dataplaneTerminal = true;
-        await onDataplaneFailed(dataplane);
+    // Native health owns every real runtime. The WebView may display the
+    // evidence and pause quality work, but it must never race native restart or
+    // turn a native cooldown into a frontend node switch.
+    const nativeOwner = dataplane.nativeRecoveryOwner === "native"
+      || ["recovering", "cooldown", "pressure_wait", "exhausted", "terminal", "cleanup_error"]
+        .includes(dataplane.nativeRecoveryState);
+    if (nativeOwner) {
+      if (dataplane.nativeRecoveryState === "terminal" && active(run) && !dataplaneTerminal) {
+        const confirmed = await onDataplaneFailed(dataplane);
+        if (confirmed === true) dataplaneTerminal = true;
+      }
+      if (!dataplaneEmergencyPaused) {
+        dataplaneEmergencyPaused = true;
+        getQualityEngine()?.pauseForEmergency?.();
       }
       return true;
     }
 
-    dataplaneRecoveries.push(Date.now());
+    // Legacy/fallback snapshots without a native owner still fail closed under
+    // pressure; pressure is not evidence that the dataplane recovered.
+    if (pressure) return true;
+    if (!active(run)) return true;
+    if (nowFn() < dataplaneRecoveryGraceUntil || dataplaneRecoveryBusy) return true;
+
+    const decision = dataplaneRecoveryDecision();
+    if (decision.state === "cooldown") return true;
+    if (decision.state === "exhausted") {
+      return failClosedAfterExhaustion(run, dataplane);
+    }
+
+    dataplaneRecoveries.push(nowFn());
     dataplaneRecoveryBusy = true;
+    dataplaneEmergencyPaused = true;
     getQualityEngine()?.pauseForEmergency?.();
     toastFn(tr("conn.applyingSettings"), "warn", 5000, { group: "conn", connecting: true });
     try {
@@ -118,14 +190,14 @@ export function initHealthWatchdog({
         snapshot: dataplane,
       });
       if (recovered) {
-        dataplaneRecoveryGraceUntil = Date.now() + DATAPLANE_RECOVERY_GRACE_MS;
+        dataplaneRecoveryGraceUntil = nowFn() + DATAPLANE_RECOVERY_GRACE_MS;
         dataplaneTerminal = false;
       }
     } catch (error) {
       console.warn("dataplane recovery failed", error);
     } finally {
       dataplaneRecoveryBusy = false;
-      getQualityEngine()?.resumeAfterEmergency?.();
+      resetEmergencyPause();
     }
     return true;
   }
@@ -147,6 +219,10 @@ export function initHealthWatchdog({
     dataplaneRecoveryBusy = false;
     dataplaneRecoveryGraceUntil = 0;
     dataplaneTerminal = false;
+    dataplaneTerminalBusy = false;
+    dataplaneTerminalRetryAt = 0;
+    dataplaneTerminalAttempts = [];
+    dataplaneEmergencyPaused = false;
     timer = setIntervalFn(tick, HEALTH_TICK_MS);
   }
 
@@ -156,6 +232,10 @@ export function initHealthWatchdog({
     dataplaneRecoveryBusy = false;
     dataplaneRecoveryGraceUntil = 0;
     dataplaneTerminal = false;
+    dataplaneTerminalBusy = false;
+    dataplaneTerminalRetryAt = 0;
+    dataplaneTerminalAttempts = [];
+    dataplaneEmergencyPaused = false;
     if (timer) { clearIntervalFn(timer); timer = null; }
   }
 
@@ -226,6 +306,13 @@ export function initHealthWatchdog({
 
       if (!active(run)) return;
       if (!snap.singbox_running) {
+        // Native health owns the runtime lifecycle. A process death is still
+        // evidence for its local recovery/terminal path; do not let this older
+        // WebView branch race native stop/start between two health snapshots.
+        if (snap.dataplane?.nativeRecoveryOwner === "native") {
+          await handleDataplaneHealth(run, snap);
+          return;
+        }
         // Причину смерти snapshot читает синхронно с running-статусом (до
         // shutdownCore, который сбрасывает флаги).
         const why = snap.last_error;

--- a/src/lib/health-watchdog.js
+++ b/src/lib/health-watchdog.js
@@ -1,7 +1,10 @@
-// Ninety · health-watchdog (liveness ядер + bridge-reconnect). Вынесено из main.js.
+// Ninety · health-watchdog (liveness ядер + dataplane recovery + bridge-reconnect).
+// Вынесено из main.js.
 // Пока connected — раз в 5с дёргаем health_snapshot:
 //   sing-box упал → туннель закрыт: снять прокси, idle, нотифай с причиной, логи.
 //   xray/naive/TT-мост упал → авто-реконнект (пересобирает конфиг и поднимает ядра).
+//   native dataplane failed → bounded node switch/full reconnect; pressure не
+//   запускает quality-лесенку и ждёт восстановления ресурсов.
 // После аварийного fail-closed shutdown тот же таймер остаётся в guard-only
 // режиме и следит только за WFP, пока пользователь явно не снимет блок.
 // Всё, что тянется из main (текущее состояние, флаг установки апдейта, гашение ядра,
@@ -16,6 +19,10 @@ const invoke = window.__TAURI__?.core?.invoke
   ?? (() => Promise.reject(new Error("Tauri invoke недоступен")));
 
 const HEALTH_TICK_MS = 5000;
+const DATAPLANE_RECOVERY_COOLDOWN_MS = 60_000;
+const DATAPLANE_RECOVERY_WINDOW_MS = 15 * 60_000;
+const DATAPLANE_RECOVERY_MAX = 3;
+const DATAPLANE_RECOVERY_GRACE_MS = 30_000;
 // Кап догоняющих реконнектов мостов (xray/naive/TT). Смерть моста сразу на старте
 // фейлит start_singbox (fail-fast в Rust), но смерть в середине сессии лечится
 // реконнектом — без капа стабильно падающий мост зациклил бы «упал → реконнект →
@@ -38,6 +45,8 @@ export function initHealthWatchdog({
   isKillSwitchRequired = () => false,
   rearmKillSwitch = async () => false,
   reconcileKillSwitch = async () => true,
+  recoverDataplane = async () => false,
+  onDataplaneFailed = async () => false,
   invoke: invokeFn = invoke,
   toast: toastFn = toast,
   notify: notifyFn = notify,
@@ -50,6 +59,10 @@ export function initHealthWatchdog({
   let bridgeReconnects = [];
   let generation = 0;
   let killSwitchAlerted = false;
+  let dataplaneRecoveries = [];
+  let dataplaneRecoveryBusy = false;
+  let dataplaneRecoveryGraceUntil = 0;
+  let dataplaneTerminal = false;
 
   const current = (run) => run === generation && !isUpdateInstalling();
   const active = (run) => current(run) && getState() === "connected";
@@ -59,6 +72,61 @@ export function initHealthWatchdog({
     bridgeReconnects = bridgeReconnects.filter((ts) => ts > cut);
     if (bridgeReconnects.length >= BRIDGE_RECONNECT_MAX) return false;
     bridgeReconnects.push(Date.now());
+    return true;
+  }
+
+  function dataplaneRecoveryAllowed() {
+    const now = Date.now();
+    const cut = now - DATAPLANE_RECOVERY_WINDOW_MS;
+    dataplaneRecoveries = dataplaneRecoveries.filter((ts) => ts > cut);
+    const last = dataplaneRecoveries.at(-1) || 0;
+    return dataplaneRecoveries.length < DATAPLANE_RECOVERY_MAX
+      && now - last >= DATAPLANE_RECOVERY_COOLDOWN_MS;
+  }
+
+  async function handleDataplaneHealth(run, snap) {
+    const dataplane = snap?.dataplane;
+    if (!dataplane) return false;
+    if (dataplane.state === "inactive") return false;
+    const pressure = dataplane.hostPressure === true || dataplane.state === "pressure";
+    getQualityEngine()?.setHostPressure?.(pressure);
+
+    if (dataplane.state === "healthy") {
+      dataplaneRecoveryGraceUntil = 0;
+      dataplaneTerminal = false;
+      return false;
+    }
+    if (pressure || dataplane.state !== "failed") return true;
+    if (!active(run)) return true;
+    if (Date.now() < dataplaneRecoveryGraceUntil || dataplaneRecoveryBusy) return true;
+
+    if (!dataplaneRecoveryAllowed()) {
+      if (!dataplaneTerminal) {
+        dataplaneTerminal = true;
+        await onDataplaneFailed(dataplane);
+      }
+      return true;
+    }
+
+    dataplaneRecoveries.push(Date.now());
+    dataplaneRecoveryBusy = true;
+    getQualityEngine()?.pauseForEmergency?.();
+    toastFn(tr("conn.applyingSettings"), "warn", 5000, { group: "conn", connecting: true });
+    try {
+      const recovered = await recoverDataplane({
+        reason: dataplane.reason || "dataplane_failed",
+        snapshot: dataplane,
+      });
+      if (recovered) {
+        dataplaneRecoveryGraceUntil = Date.now() + DATAPLANE_RECOVERY_GRACE_MS;
+        dataplaneTerminal = false;
+      }
+    } catch (error) {
+      console.warn("dataplane recovery failed", error);
+    } finally {
+      dataplaneRecoveryBusy = false;
+      getQualityEngine()?.resumeAfterEmergency?.();
+    }
     return true;
   }
 
@@ -76,12 +144,18 @@ export function initHealthWatchdog({
     if (timer) return;
     generation++;
     killSwitchAlerted = false;
+    dataplaneRecoveryBusy = false;
+    dataplaneRecoveryGraceUntil = 0;
+    dataplaneTerminal = false;
     timer = setIntervalFn(tick, HEALTH_TICK_MS);
   }
 
   function stop() {
     generation++;
     killSwitchAlerted = false;
+    dataplaneRecoveryBusy = false;
+    dataplaneRecoveryGraceUntil = 0;
+    dataplaneTerminal = false;
     if (timer) { clearIntervalFn(timer); timer = null; }
   }
 
@@ -189,6 +263,7 @@ export function initHealthWatchdog({
         reconnectForSourceChange(tr("conn.clientReconnect"));
         return;
       }
+      if (await handleDataplaneHealth(run, snap)) return;
       // Liveness OK — отдаём ход движку качества (детект троттла/деградации).
       // Fire-and-forget: проба до 4с не должна держать busy и тормозить следующий
       // liveness-тик; у движка свои guard'ы probing/remediating.

--- a/src/lib/quality-engine.js
+++ b/src/lib/quality-engine.js
@@ -72,6 +72,8 @@ export function createQualityEngine({
   let reconnectTimes = [];      // timestamps реконнектов для часового капа
   let reconnectHandoff = false; // R3/R4 ждёт новую VPN-сессию
   let lastState = "UNKNOWN";
+  let hostPressure = false;     // native watchdog заметил starvation/low memory
+  let emergencyLocked = false;  // аварийный recovery владеет runtime
   const passive = [];           // [{t, down}] скользящее окно
   const sessionActive = (epoch) => running && epoch === sessionEpoch;
 
@@ -160,7 +162,8 @@ export function createQualityEngine({
   // ── Тик (зовётся из healthTick после liveness-OK) ──────
   async function tick() {
     const epoch = sessionEpoch;
-    if (!sessionActive(epoch) || !cfg.enabled || reconnectHandoff || remediatingEpoch === epoch || probingEpoch === epoch) return;
+    if (!sessionActive(epoch) || !cfg.enabled || hostPressure || emergencyLocked
+      || reconnectHandoff || remediatingEpoch === epoch || probingEpoch === epoch) return;
     const timestamp = now();
 
     const { peak, last } = passiveView();
@@ -357,6 +360,8 @@ export function createQualityEngine({
     const epoch = sessionEpoch;
     cfg = normalizeOpts({ ...cfg, ...o });
     running = true;
+    hostPressure = false;
+    emergencyLocked = false;
     badStreak = 0; goodStreak = 0; lastState = "UNKNOWN";
     passive.length = 0;
     lastProbeAt = now(); // дать туннелю осесть перед первой пробой
@@ -375,12 +380,44 @@ export function createQualityEngine({
   function onIdle() {
     sessionEpoch++;
     running = false;
+    hostPressure = false;
+    emergencyLocked = false;
     passive.length = 0;
   }
   function setOptions(o) { cfg = normalizeOpts({ ...cfg, ...o }); }
+  function setHostPressure(active) {
+    const next = !!active;
+    if (hostPressure === next) return;
+    hostPressure = next;
+    badStreak = 0;
+    goodStreak = 0;
+    lastState = next ? "PRESSURE" : "UNKNOWN";
+    // После выхода из pressure mode разрешаем одну пробу без ожидания полного
+    // idle-интервала, но не запускаем её в тот же момент, что native watchdog.
+    lastProbeAt = next ? now() : now() - PROBE_MIN_GAP_MS;
+  }
+  function pauseForEmergency() {
+    // Инвалидируем уже выполняющуюся quality-лесенку/пробу, не переводя UI в
+    // idle: аварийный coordinator сам решит, будет ли простой switch или restart.
+    sessionEpoch++;
+    emergencyLocked = true;
+    badStreak = 0;
+    goodStreak = 0;
+    probingEpoch = null;
+    remediatingEpoch = null;
+    reconnectHandoff = false;
+  }
+  function resumeAfterEmergency() {
+    emergencyLocked = false;
+    badStreak = 0;
+    goodStreak = 0;
+    lastState = "UNKNOWN";
+    lastProbeAt = now();
+  }
 
   return {
     onConnected, onIdle, tick, updatePassive, setOptions,
+    setHostPressure, pauseForEmergency, resumeAfterEmergency,
     getSamples: () => samples.slice(), // снимок ring-буфера для осциллограммы
     get state() { return lastState; },
     get isRemediating() { return remediatingEpoch === sessionEpoch; },

--- a/src/main.js
+++ b/src/main.js
@@ -1120,7 +1120,23 @@ async function recoverDataplane() {
     && await verifyEmergencyDataplane();
 }
 
-async function failDataplane() {
+async function failDataplane(dataplane = {}) {
+  // Native recovery has already failed closed by the time this callback is
+  // reached. If WebView2 is responsive, give the existing bounded candidate /
+  // reconnect path one chance to recover the session. The native path remains
+  // the safety net when the frontend is hung, and strict privacy keeps its
+  // pinned-node policy instead of trying alternate candidates here.
+  const strictRuntime = strictPrivacyRequested() || dataplane?.unmonitoredPrivacyMode === true;
+  if (!strictRuntime) {
+    try {
+      if (await recoverDataplane({
+        reason: dataplane.reason || "all_candidates_failed",
+        snapshot: dataplane,
+      })) return true;
+    } catch (error) {
+      console.warn("frontend dataplane fallback failed", error);
+    }
+  }
   const preserved = killSwitchMustSurviveRuntimeStop();
   const closed = await shutdownCore({ preserveKillSwitch: preserved });
   if (!closed) return false;

--- a/src/main.js
+++ b/src/main.js
@@ -45,7 +45,7 @@ import { initTray, syncTrayMenu } from "/lib/tray.js";
 import { startClashStream, stopClashStream, formatRate } from "/lib/clash-stream.js";
 import { createConnectionAttemptGate } from "/lib/connection-attempt.js";
 import { createCoreStartBarrier } from "/lib/connection-start-barrier.js";
-import { cancelPendingSelections, configureClashRuntime, gradeDelay, pickEffectiveNode, getProxies, lastDelay, selectProxy, refreshEffectiveDelay } from "/lib/clash-api.js";
+import { cancelPendingSelections, configureClashRuntime, gradeDelay, pickEffectiveNode, getProxies, lastDelay, selectProxy, refreshEffectiveDelay, testNode } from "/lib/clash-api.js";
 import { fetchPublicIp, maskIp, bindIpReveal } from "/lib/ip-info.js";
 import { notify } from "/lib/notify.js";
 import { toast } from "/lib/toast.js";
@@ -1041,8 +1041,83 @@ async function performAutoReconnectOnce(reason, epoch) {
   }
 }
 
+const EMERGENCY_PROBE_ENDPOINT = "https://speed.cloudflare.com/__down?bytes=65536";
+
+async function verifyEmergencyDataplane() {
+  const options = loadOptions();
+  const port = Number(options.inbound?.mixedPort) || 7890;
+  try {
+    const result = await invoke("probe_quality", {
+      port,
+      endpoints: [EMERGENCY_PROBE_ENDPOINT],
+      sampleBytes: 64 * 1024,
+      budgetMs: 2500,
+    });
+    return result?.ok === true && result?.stalled !== true
+      && Number(result?.bytes) >= 64 * 1024;
+  } catch {
+    return false;
+  }
+}
+
+// Аварийный путь отделён от anti-throttle лесенки: он не спрашивает юзера,
+// не использует её часовой бюджет и сначала пробует дешёвое переключение на
+// проверенную альтернативу. Если локальный Clash API завис, сразу сработает
+// controlled full reconnect через уже существующий lifecycle-барьер.
+async function recoverDataplane() {
+  if (state !== "connected") return false;
+  const token = runtimeIdentity.capture();
+  if (!token) return false;
+
+  const nodes = qualityNodesFromSource();
+  if (nodes.length >= 2) {
+    let proxies;
+    try {
+      proxies = (await getProxies(undefined, { token, fresh: true }))?.proxies || {};
+    } catch {
+      proxies = {};
+    }
+    const current = currentEffectiveTag || pickEffectiveNode({ proxies });
+    const candidates = rankByDelay(
+      nodes.filter((node) => node.clashTag && node.clashTag !== current),
+      proxies,
+    ).slice(0, 3);
+
+    for (const candidate of candidates) {
+      if (!runtimeIdentity.isCurrent(token) || state !== "connected") return false;
+      try {
+        const tested = await testNode(candidate.clashTag, { token, timeoutMs: 3000 });
+        const delay = Number(tested?.delay) || 0;
+        if (delay <= 0 || delay >= 65_000) continue;
+        const selected = await selectProxy("proxy", candidate.clashTag, { token });
+        if (selected?.stale || !runtimeIdentity.isCurrent(token)) continue;
+        if (await verifyEmergencyDataplane()) return true;
+      } catch {
+        // Следующая candidate либо полный reconnect — ниже.
+      }
+    }
+  }
+
+  const request = beginSourceReconnect(t("conn.applyingSettings"));
+  if (!request) return false;
+  const connected = await request.completion;
+  return connected === true && state === "connected"
+    && await verifyEmergencyDataplane();
+}
+
+async function failDataplane() {
+  const preserved = killSwitchMustSurviveRuntimeStop();
+  const closed = await shutdownCore({ preserveKillSwitch: preserved });
+  if (!closed) return false;
+  toast(t("conn.coreStopped"), "error", 7000, { group: "conn", desc: t("conn.coreStoppedDesc") });
+  notify(t("conn.notifyClosedTitle"), t("conn.notifyClosedBody"));
+  switchView("logs");
+  return true;
+}
+
 // ── health-watchdog — /lib/health-watchdog.js ──────────────
-// Liveness ядер + bridge-reconnect вынесены в модуль; здесь инстанс с инжектом
+// Liveness ядер, native dataplane recovery и bridge-reconnect вынесены в модуль;
+// здесь инстанс с инжектом
 // состояния/реконнекта/движка качества. Алиасы сохраняют имена вызовов из setState
 // (start/stopHealthWatchdog) — их не трогаем. getQualityEngine — геттер, т.к.
 // qualityEngine определяется ниже по файлу; вызывается только в runtime-тике.
@@ -1060,6 +1135,8 @@ const healthWatchdog = initHealthWatchdog({
     policyMode: preservedKillSwitchPolicyMode(),
   }),
   reconcileKillSwitch: () => applyKillSwitch(state === "connected"),
+  recoverDataplane,
+  onDataplaneFailed: failDataplane,
 });
 const startHealthWatchdog = healthWatchdog.start;
 const stopHealthWatchdog = healthWatchdog.stop;

--- a/src/main.js
+++ b/src/main.js
@@ -45,7 +45,7 @@ import { initTray, syncTrayMenu } from "/lib/tray.js";
 import { startClashStream, stopClashStream, formatRate } from "/lib/clash-stream.js";
 import { createConnectionAttemptGate } from "/lib/connection-attempt.js";
 import { createCoreStartBarrier } from "/lib/connection-start-barrier.js";
-import { cancelPendingSelections, configureClashRuntime, gradeDelay, pickEffectiveNode, getProxies, lastDelay, selectProxy, refreshEffectiveDelay, testNode } from "/lib/clash-api.js";
+import { cancelPendingSelections, configureClashRuntime, gradeDelay, pickEffectiveNode, pickSelectorNow, getProxies, lastDelay, selectProxy, refreshEffectiveDelay, testNode } from "/lib/clash-api.js";
 import { fetchPublicIp, maskIp, bindIpReveal } from "/lib/ip-info.js";
 import { notify } from "/lib/notify.js";
 import { toast } from "/lib/toast.js";
@@ -1041,20 +1041,12 @@ async function performAutoReconnectOnce(reason, epoch) {
   }
 }
 
-const EMERGENCY_PROBE_ENDPOINT = "https://speed.cloudflare.com/__down?bytes=65536";
-
 async function verifyEmergencyDataplane() {
   const options = loadOptions();
   const port = Number(options.inbound?.mixedPort) || 7890;
   try {
-    const result = await invoke("probe_quality", {
-      port,
-      endpoints: [EMERGENCY_PROBE_ENDPOINT],
-      sampleBytes: 64 * 1024,
-      budgetMs: 2500,
-    });
-    return result?.ok === true && result?.stalled !== true
-      && Number(result?.bytes) >= 64 * 1024;
+    const result = await invoke("probe_health", { port });
+    return result?.ok === true;
   } catch {
     return false;
   }
@@ -1077,9 +1069,18 @@ async function recoverDataplane() {
     } catch {
       proxies = {};
     }
-    const current = currentEffectiveTag || pickEffectiveNode({ proxies });
+    const originalSelector = pickSelectorNow(proxies) || "auto";
+    const originalEffective = currentEffectiveTag || pickEffectiveNode({ proxies });
+    const sourceScope = `${token.sourceKey || "source"}:${token.sourceRevision || 0}`;
+    const now = Date.now();
+    for (const [key, expiry] of dataplaneCandidateCooldown) {
+      if (expiry <= now) dataplaneCandidateCooldown.delete(key);
+    }
+    const current = originalEffective;
     const candidates = rankByDelay(
-      nodes.filter((node) => node.clashTag && node.clashTag !== current),
+      nodes.filter((node) => node.clashTag
+        && node.clashTag !== current
+        && !dataplaneCandidateCooldown.has(`${sourceScope}:${node.clashTag}`)),
       proxies,
     ).slice(0, 3);
 
@@ -1092,8 +1093,22 @@ async function recoverDataplane() {
         const selected = await selectProxy("proxy", candidate.clashTag, { token });
         if (selected?.stale || !runtimeIdentity.isCurrent(token)) continue;
         if (await verifyEmergencyDataplane()) return true;
+        dataplaneCandidateCooldown.set(`${sourceScope}:${candidate.clashTag}`, Date.now() + DATAPLANE_CANDIDATE_COOLDOWN_MS);
       } catch {
         // Следующая candidate либо полный reconnect — ниже.
+        dataplaneCandidateCooldown.set(`${sourceScope}:${candidate.clashTag}`, Date.now() + DATAPLANE_CANDIDATE_COOLDOWN_MS);
+      }
+    }
+
+    // Candidate validation may have changed Clash's selector. Restore the
+    // original selector before falling back to a full lifecycle reconnect;
+    // never leave a failed emergency candidate active by accident.
+    if (runtimeIdentity.isCurrent(token) && originalSelector) {
+      try {
+        const restored = await selectProxy("proxy", originalSelector, { token });
+        if (!restored?.stale && originalEffective) currentEffectiveTag = originalEffective;
+      } catch {
+        // Full reconnect below will still rebuild the original runtime policy.
       }
     }
   }
@@ -1293,6 +1308,8 @@ const qualityEngine = createQualityEngine({
 // Cooldown нод, забракованных R2 — чтобы не выбирать их снова сразу.
 const QUALITY_EXCLUDE_MS = 5 * 60_000;
 const qualityExcluded = new Map(); // clashTag → expiry ts
+const DATAPLANE_CANDIDATE_COOLDOWN_MS = 5 * 60_000;
+const dataplaneCandidateCooldown = new Map(); // source/revision/tag → expiry ts
 // Ноды активного источника с clash-тэгами (зеркало proxies-view.nodesFromSource).
 function qualityNodesFromSource() {
   const src = getActiveSource();
@@ -2845,6 +2862,9 @@ async function connectNetwork({ epoch = networkIntentEpoch } = {}) {
         configHash: runtimeToken.configHash,
         strictPrivacy: !!runtimeInfo.strictPrivacy,
         pinnedNodeTag: runtimeInfo.pinnedNodeTag,
+        systemProxyBypassLan: options.route?.bypassLan !== false,
+        killSwitchExpected: !!runtimeInfo.strictPrivacy
+          || (!!options.general?.killSwitch && runtimeInfo.mode !== "tun"),
       }));
       if (!runtimeSnapshot?.running || !Number(runtimeSnapshot.processGeneration)) {
         throw new Error("start_singbox не вернул подтверждённый runtime snapshot");

--- a/tests/health-watchdog.test.mjs
+++ b/tests/health-watchdog.test.mjs
@@ -185,3 +185,87 @@ test("поздний rearm отменённой policy завершается а
 
   assert.equal(reconciles, 1);
 });
+
+test("dataplane failed запускает bounded recovery и блокирует quality engine", async () => {
+  let recoveries = 0;
+  let pauses = 0;
+  let resumes = 0;
+  let qualityTicks = 0;
+  const quality = {
+    setHostPressure: () => {},
+    pauseForEmergency: () => { pauses++; },
+    resumeAfterEmergency: () => { resumes++; },
+    tick: async () => { qualityTicks++; },
+  };
+  const watchdog = initHealthWatchdog({
+    getState: () => "connected",
+    isUpdateInstalling: () => false,
+    shutdownCore: async () => true,
+    reconnectForSourceChange: () => {},
+    switchView: () => {},
+    getQualityEngine: () => quality,
+    recoverDataplane: async () => { recoveries++; return true; },
+    invoke: async () => ({
+      singbox_running: true,
+      xray: "none",
+      sidecar: "none",
+      kill_switch_active: false,
+      dataplane: {
+        state: "failed",
+        reason: "dataplane_stalled",
+        hostPressure: false,
+      },
+    }),
+    toast: () => {},
+    notify: () => {},
+    t: (key) => key,
+    setInterval: () => 1,
+    clearInterval: () => {},
+  });
+
+  watchdog.start();
+  await watchdog.tick();
+  await watchdog.tick();
+
+  assert.equal(recoveries, 1);
+  assert.equal(pauses, 1);
+  assert.equal(resumes, 1);
+  assert.equal(qualityTicks, 0, "обычный quality engine не должен вмешиваться");
+});
+
+test("pressure mode не запускает recovery и гасит фоновую quality-пробу", async () => {
+  let recoveries = 0;
+  let pressure = false;
+  let qualityTicks = 0;
+  const watchdog = initHealthWatchdog({
+    getState: () => "connected",
+    isUpdateInstalling: () => false,
+    shutdownCore: async () => true,
+    reconnectForSourceChange: () => {},
+    switchView: () => {},
+    getQualityEngine: () => ({
+      setHostPressure: (value) => { pressure = value; },
+      tick: async () => { qualityTicks++; },
+    }),
+    recoverDataplane: async () => { recoveries++; return true; },
+    invoke: async () => ({
+      singbox_running: true,
+      xray: "none",
+      sidecar: "none",
+      kill_switch_active: false,
+      dataplane: { state: "pressure", hostPressure: true },
+    }),
+    toast: () => {},
+    notify: () => {},
+    t: (key) => key,
+    setInterval: () => 1,
+    clearInterval: () => {},
+  });
+
+  watchdog.start();
+  await watchdog.tick();
+
+  assert.equal(pressure, true);
+  assert.equal(recoveries, 0);
+  assert.equal(qualityTicks, 0);
+});

--- a/tests/health-watchdog.test.mjs
+++ b/tests/health-watchdog.test.mjs
@@ -308,6 +308,82 @@ test("cooldown не превращается в terminal exhaustion", async () =
   assert.equal(recoveries, 2);
 });
 
+test("recovery budget считает три попытки и очищает старые попытки по окну", async () => {
+  let now = 0;
+  let recoveries = 0;
+  let terminal = 0;
+  const watchdog = initHealthWatchdog({
+    getState: () => "connected",
+    isUpdateInstalling: () => false,
+    shutdownCore: async () => true,
+    reconnectForSourceChange: () => {},
+    switchView: () => {},
+    getQualityEngine: () => null,
+    recoverDataplane: async () => { recoveries++; return false; },
+    onDataplaneFailed: async () => { terminal++; return false; },
+    now: () => now,
+    invoke: async () => ({
+      singbox_running: true,
+      xray: "none",
+      sidecar: "none",
+      dataplane: { state: "failed", hostPressure: false },
+    }),
+    toast: () => {},
+    notify: () => {},
+    t: (key) => key,
+    setInterval: () => 1,
+    clearInterval: () => {},
+  });
+
+  watchdog.start();
+  await watchdog.tick();
+  now = 60_000;
+  await watchdog.tick();
+  now = 120_000;
+  await watchdog.tick();
+  assert.equal(recoveries, 3);
+  now = 900_001;
+  await watchdog.tick();
+  assert.equal(recoveries, 4, "попытки старше recovery window больше не блокируют recovery");
+  assert.equal(terminal, 0);
+});
+
+test("успешное recovery получает grace и не запускается повторно до его окончания", async () => {
+  let now = 0;
+  let recoveries = 0;
+  const watchdog = initHealthWatchdog({
+    getState: () => "connected",
+    isUpdateInstalling: () => false,
+    shutdownCore: async () => true,
+    reconnectForSourceChange: () => {},
+    switchView: () => {},
+    getQualityEngine: () => null,
+    recoverDataplane: async () => { recoveries++; return true; },
+    onDataplaneFailed: async () => true,
+    now: () => now,
+    invoke: async () => ({
+      singbox_running: true,
+      xray: "none",
+      sidecar: "none",
+      dataplane: { state: "failed", hostPressure: false },
+    }),
+    toast: () => {},
+    notify: () => {},
+    t: (key) => key,
+    setInterval: () => 1,
+    clearInterval: () => {},
+  });
+
+  watchdog.start();
+  await watchdog.tick();
+  now = 30_000;
+  await watchdog.tick();
+  assert.equal(recoveries, 1, "stale failure во время grace не должен запускать новый action");
+  now = 30_001;
+  await watchdog.tick();
+  assert.equal(recoveries, 1, "после grace ещё действует cooldown первой попытки");
+});
+
 test("terminal latch появляется только после подтверждённого cleanup", async () => {
   let now = 0;
   let recoveries = 0;
@@ -385,4 +461,43 @@ test("native owner не запускает frontend recovery даже при fai
   await watchdog.tick();
   assert.equal(recoveries, 0);
   assert.equal(pauses, 1);
+});
+
+test("native terminal cleanup остаётся подтверждаемым и bounded", async () => {
+  let now = 0;
+  let terminalAttempts = 0;
+  const watchdog = initHealthWatchdog({
+    getState: () => "connected",
+    isUpdateInstalling: () => false,
+    shutdownCore: async () => false,
+    reconnectForSourceChange: () => {},
+    switchView: () => {},
+    getQualityEngine: () => null,
+    onDataplaneFailed: async () => { terminalAttempts++; return false; },
+    now: () => now,
+    invoke: async () => ({
+      singbox_running: true,
+      xray: "none",
+      sidecar: "none",
+      dataplane: {
+        state: "failed",
+        dataplaneState: "failed",
+        nativeRecoveryOwner: "native",
+        nativeRecoveryState: "terminal",
+      },
+    }),
+    toast: () => {},
+    notify: () => {},
+    t: (key) => key,
+    setInterval: () => 1,
+    clearInterval: () => {},
+  });
+
+  watchdog.start();
+  await watchdog.tick();
+  await watchdog.tick();
+  assert.equal(terminalAttempts, 1, "terminal snapshot должен запускать cleanup один раз");
+  now = 60_000;
+  await watchdog.tick();
+  assert.equal(terminalAttempts, 2, "после cooldown cleanup может быть повторён");
 });

--- a/tests/health-watchdog.test.mjs
+++ b/tests/health-watchdog.test.mjs
@@ -269,3 +269,120 @@ test("pressure mode не запускает recovery и гасит фонову�
   assert.equal(recoveries, 0);
   assert.equal(qualityTicks, 0);
 });
+
+test("cooldown не превращается в terminal exhaustion", async () => {
+  let now = 0;
+  let recoveries = 0;
+  let terminal = 0;
+  const watchdog = initHealthWatchdog({
+    getState: () => "connected",
+    isUpdateInstalling: () => false,
+    shutdownCore: async () => true,
+    reconnectForSourceChange: () => {},
+    switchView: () => {},
+    getQualityEngine: () => null,
+    recoverDataplane: async () => { recoveries++; return false; },
+    onDataplaneFailed: async () => { terminal++; return true; },
+    now: () => now,
+    invoke: async () => ({
+      singbox_running: true,
+      xray: "none",
+      sidecar: "none",
+      dataplane: { state: "failed", hostPressure: false },
+    }),
+    toast: () => {},
+    notify: () => {},
+    t: (key) => key,
+    setInterval: () => 1,
+    clearInterval: () => {},
+  });
+
+  watchdog.start();
+  await watchdog.tick();
+  now = 1000;
+  await watchdog.tick();
+  assert.equal(recoveries, 1, "cooldown не должен запускать второй recovery");
+  assert.equal(terminal, 0, "cooldown не является terminal состоянием");
+  now = 61_000;
+  await watchdog.tick();
+  assert.equal(recoveries, 2);
+});
+
+test("terminal latch появляется только после подтверждённого cleanup", async () => {
+  let now = 0;
+  let recoveries = 0;
+  let terminalAttempts = 0;
+  const watchdog = initHealthWatchdog({
+    getState: () => "connected",
+    isUpdateInstalling: () => false,
+    shutdownCore: async () => false,
+    reconnectForSourceChange: () => {},
+    switchView: () => {},
+    getQualityEngine: () => null,
+    recoverDataplane: async () => { recoveries++; return false; },
+    onDataplaneFailed: async () => { terminalAttempts++; return false; },
+    now: () => now,
+    invoke: async () => ({
+      singbox_running: true,
+      xray: "none",
+      sidecar: "none",
+      dataplane: { state: "failed", hostPressure: false },
+    }),
+    toast: () => {},
+    notify: () => {},
+    t: (key) => key,
+    setInterval: () => 1,
+    clearInterval: () => {},
+  });
+
+  watchdog.start();
+  for (let attempt = 0; attempt < 4; attempt++) {
+    await watchdog.tick();
+    if (attempt < 3) now += 60_000;
+  }
+  assert.equal(recoveries, 3);
+  assert.equal(terminalAttempts, 1);
+  await watchdog.tick();
+  assert.equal(terminalAttempts, 1, "неудачный cleanup не должен спамить вызовами");
+});
+
+test("native owner не запускает frontend recovery даже при failed dataplane", async () => {
+  let recoveries = 0;
+  let pauses = 0;
+  const watchdog = initHealthWatchdog({
+    getState: () => "connected",
+    isUpdateInstalling: () => false,
+    shutdownCore: async () => true,
+    reconnectForSourceChange: () => {},
+    switchView: () => {},
+    getQualityEngine: () => ({
+      setHostPressure: () => {},
+      pauseForEmergency: () => { pauses++; },
+      tick: async () => {},
+    }),
+    recoverDataplane: async () => { recoveries++; return true; },
+    invoke: async () => ({
+      singbox_running: true,
+      xray: "none",
+      sidecar: "none",
+      dataplane: {
+        state: "failed",
+        dataplaneState: "failed",
+        nativeRecoveryOwner: "native",
+        nativeRecoveryState: "recovering",
+        hostPressure: true,
+      },
+    }),
+    toast: () => {},
+    notify: () => {},
+    t: (key) => key,
+    setInterval: () => 1,
+    clearInterval: () => {},
+  });
+
+  watchdog.start();
+  await watchdog.tick();
+  await watchdog.tick();
+  assert.equal(recoveries, 0);
+  assert.equal(pauses, 1);
+});

--- a/tests/quality.test.mjs
+++ b/tests/quality.test.mjs
@@ -244,3 +244,53 @@ test("выключенный quality engine не прогревает локал
   await Promise.resolve();
   assert.equal(asnCalls, 0);
 });
+
+test("pressure mode временно отключает фоновые quality probes", async () => {
+  installStorage();
+  let probes = 0;
+  const engine = createQualityEngine({
+    invoke: async (cmd) => {
+      if (cmd === "probe_quality") probes++;
+      return GOOD;
+    },
+    actions: {},
+    opts: { enabled: true },
+  });
+
+  engine.onConnected({ idleProbeSec: 60 });
+  armSuspect(engine);
+  engine.setHostPressure(true);
+  await engine.tick();
+  assert.equal(probes, 0);
+
+  engine.setHostPressure(false);
+  await engine.tick();
+  assert.equal(probes, 1, "после выхода из pressure mode probe должен вернуться");
+});
+
+test("emergency pause инвалидирует текущую quality remediation", async () => {
+  installStorage();
+  let probeRelease;
+  const probe = new Promise((resolve) => { probeRelease = resolve; });
+  let probes = 0;
+  const engine = createQualityEngine({
+    invoke: async (cmd) => {
+      if (cmd !== "probe_quality") return undefined;
+      probes++;
+      return probe;
+    },
+    actions: {},
+    opts: { enabled: true },
+  });
+
+  engine.onConnected({ idleProbeSec: 60 });
+  armSuspect(engine);
+  const running = engine.tick();
+  while (probes === 0) await Promise.resolve();
+  engine.pauseForEmergency();
+  probeRelease(GOOD);
+  await running;
+
+  assert.equal(engine.isRemediating, false);
+  assert.equal(engine.state, "UNKNOWN");
+});


### PR DESCRIPTION
## Что изменено

Добавлен первый MVP отказоустойчивости VPN-клиента Ninety при высокой нагрузке CPU/ОЗУ:

- native Rust-watchdog проверяет реальный datapath через существующий `probe-in`;
- добавлены состояния `healthy`, `suspect`, `pressure`, `failed`;
- при resource pressure отключаются фоновые quality probes;
- добавлено ограниченное восстановление: проверка альтернативных нод, переключение, затем reconnect источника;
- введены cooldown, grace period и лимит попыток для защиты от циклических рестартов;
- VPN-процессы получают приоритет `ABOVE_NORMAL` в Windows;
- сохранена текущая политика strict privacy и kill switch;
- добавлены тесты и описание архитектуры.

## Почему

При полной загрузке CPU и почти исчерпанной памяти процессы Ninety могли оставаться запущенными, но переставать обслуживать сетевой datapath. Проверка только PID/процесса не выявляла такой отказ.

## Проверки

- `npm test`: 254/254;
- `npm run lint`;
- `rustfmt --check`;
- `git diff --check`.

Полный Windows/Rust build должен пройти в GitHub Actions.