### PR TITLE
fix: restore routing rules UI to v0.2.40

### DIFF
--- a/src/lib/routing-view.js
+++ b/src/lib/routing-view.js
@@ -13,7 +13,7 @@ import { loadOptions, updateOption } from "/lib/options.js";
 import {
   newRule, normalizeValue, isValidValue, sanitizeRule,
 } from "/lib/routing-rules.js";
-import { listNetworkProcesses, getConnections, snapshotNetworkTcp } from "/lib/clash-api.js";
+import { listNetworkProcesses, getConnections } from "/lib/clash-api.js";
 import { toast } from "/lib/toast.js";
 import { escapeAttr, escapeHtml as esc } from "/lib/esc.js";
 import { t, getLang } from "/lib/i18n/index.js";
@@ -82,7 +82,6 @@ export function mountRoutingRules(rootEl, opts = {}) {
   let tab = "rules";
   let monitorPaused = false;
   let monConns = [];
-  let monOsConns = [];
   let monTimer = null;
   let monExpanded = new Set(); // раскрытые группы приложений (по имени процесса)
   let dragId = null;
@@ -547,56 +546,6 @@ export function mountRoutingRules(rootEl, opts = {}) {
       return (a.process || "").localeCompare(b.process || "");
     });
   }
-
-  function endpointParts(value) {
-    const raw = String(value || "");
-    if (raw.startsWith("[")) {
-      const end = raw.indexOf("]:");
-      if (end > 0) return { host: raw.slice(1, end), port: raw.slice(end + 2) };
-    }
-    const split = raw.lastIndexOf(":");
-    return split > 0 ? { host: raw.slice(0, split), port: raw.slice(split + 1) } : { host: raw, port: "" };
-  }
-
-  function normalizedProcess(value) {
-    return String(value || "").replaceAll("\\", "/").split("/").pop().toLowerCase();
-  }
-
-  function clashOwnsOsConnection(os, clash) {
-    const local = endpointParts(os.localAddress);
-    const remote = endpointParts(os.remoteAddress);
-    return clash.some((c) => {
-      const cRemoteMatches = !c.destinationIP || c.destinationIP === remote.host;
-      const cSourcePresent = c.sourceIP && c.sourcePort;
-      const cSourceMatches = !cSourcePresent
-        || (c.sourceIP === local.host && String(c.sourcePort) === local.port);
-      if (!cRemoteMatches || !cSourceMatches) return false;
-      if (cSourcePresent) return true;
-      const cProcess = normalizedProcess(c.processPath || c.process);
-      return !!cProcess && cProcess === normalizedProcess(os.processPath || os.process);
-    });
-  }
-
-  function osOnlyConnections(os, clash) {
-    return (Array.isArray(os) ? os : []).filter((connection) =>
-      !clashOwnsOsConnection(connection, Array.isArray(clash) ? clash : []));
-  }
-
-  function groupOsConns(conns) {
-    const map = new Map();
-    for (const c of conns) {
-      const key = c.process || UNKNOWN_KEY;
-      let g = map.get(key);
-      if (!g) {
-        g = { process: c.process || null, path: c.processPath || "", conns: [] };
-        map.set(key, g);
-      }
-      if (!g.path && c.processPath) g.path = c.processPath;
-      g.conns.push(c);
-    }
-    return [...map.values()].sort((a, b) => b.conns.length - a.conns.length);
-  }
-
   function connSubRow(c) {
     const r = el("div", "rr-csub");
     const host = c.host || c.destinationIP || "—";
@@ -604,16 +553,6 @@ export function mountRoutingRules(rootEl, opts = {}) {
     r.innerHTML =
       '<span class="rr-csub__dest"><span class="rr-csub__host">' + esc(host) + "</span>" + ipLine + "</span>" +
       routeChip(c.outbound);
-    return r;
-  }
-
-  function osConnSubRow(c) {
-    const r = el("div", "rr-csub rr-os-only__row");
-    r.innerHTML =
-      '<span class="rr-csub__dest"><span class="rr-csub__host">' + esc(c.remoteAddress || "—") + "</span>" +
-      '<span class="rr-csub__ip">' + esc(c.state || "TCP") + " · " + esc(c.localAddress || "") + "</span></span>" +
-      '<span class="rr-action rr-action--direct"><span class="rr-action__dot"></span>' +
-      esc(t("rr.bypassesNinety")) + "</span>";
     return r;
   }
   function appGroup(g) {
@@ -658,8 +597,7 @@ export function mountRoutingRules(rootEl, opts = {}) {
         '<span class="rr-mon-count" id="rr-moncount"></span>' +
         '<button class="btn btn--sm" id="rr-pausebtn" type="button">' + (monitorPaused ? I.play + esc(t("rr.resume")) : I.pause + esc(t("rr.pause"))) + "</button>" +
       "</div>" +
-      '<div class="rr-appgroups" id="rr-conns"></div>' +
-      '<div id="rr-os-only"></div>';
+      '<div class="rr-appgroups" id="rr-conns"></div>';
     host.appendChild(wrap);
     wrap.querySelector("#rr-pausebtn").addEventListener("click", () => { monitorPaused = !monitorPaused; if (monitorPaused) stopMonTimer(); else startMonTimer(); renderMonitor(); });
     paintConns();
@@ -677,49 +615,18 @@ export function mountRoutingRules(rootEl, opts = {}) {
     }
     const cnt = $("#rr-moncount");
     if (cnt) cnt.textContent = monConns.length + " " + plural(monConns.length, "pluralConns");
-    const osHost = $("#rr-os-only");
-    if (osHost) {
-      osHost.innerHTML = "";
-      if (monOsConns.length) {
-        const section = el("section", "rr-os-only");
-        section.innerHTML = '<div class="rr-os-only__title">' +
-          esc(t("rr.bypassesNinety")) + " · " + monOsConns.length + "</div>";
-        for (const group of groupOsConns(monOsConns)) {
-          const groupEl = el("div", "rr-os-only__group");
-          const name = group.process || t("rr.noProcess");
-          const path = group.path && group.path !== group.process
-            ? '<span class="rr-appgrp__path">' + esc(group.path) + "</span>" : "";
-          groupEl.innerHTML = '<div class="rr-os-only__head"><span class="rr-appgrp__ico">' + I.app +
-            '</span><span class="rr-appgrp__meta"><span class="rr-appgrp__name">' + esc(name) +
-            "</span>" + path + '</span><span class="rr-appgrp__count">' + group.conns.length + "</span></div>";
-          const rows = el("div", "rr-appgrp__conns rr-os-only__conns");
-          group.conns.forEach((connection) => rows.appendChild(osConnSubRow(connection)));
-          groupEl.appendChild(rows);
-          section.appendChild(groupEl);
-        }
-        osHost.appendChild(section);
-      }
-    }
   }
   async function pollConns() {
     // Стоп, если секцию перерисовали/ушли с монитора.
     if (!rootEl.isConnected || tab !== "monitor") { stopMonTimer(); return; }
     try {
-      const [clashResult, osResult] = await Promise.allSettled([
-        getConnections(),
-        snapshotNetworkTcp(),
-      ]);
+      const list = await getConnections();
       if (!rootEl.isConnected || tab !== "monitor") return;
-      monConns = clashResult.status === "fulfilled" && Array.isArray(clashResult.value)
-        ? clashResult.value : [];
-      const osList = osResult.status === "fulfilled" && Array.isArray(osResult.value)
-        ? osResult.value : [];
-      monOsConns = osOnlyConnections(osList, monConns);
+      monConns = Array.isArray(list) ? list : [];
       paintConns();
     } catch {
       // ядро может быть offline (idle) — просто молчим, покажем пусто
       monConns = [];
-      monOsConns = [];
       paintConns();
     }
   }

--- a/src/styles/routing.css
+++ b/src/styles/routing.css
@@ -763,35 +763,6 @@
   border-top: 1px solid var(--line-1);
 }
 .rr-csub:first-child { border-top: 0; }
-.rr-os-only {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding-top: 4px;
-}
-.rr-os-only__title {
-  padding: 4px 2px 0;
-  color: var(--warn);
-  font-family: var(--font-mono);
-  font-size: 10px;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-.rr-os-only__group {
-  border: 1px solid color-mix(in srgb, var(--warn) 28%, var(--line-2));
-  border-radius: var(--r-md);
-  background: var(--ink-1);
-  overflow: hidden;
-}
-.rr-os-only__head {
-  display: grid;
-  grid-template-columns: auto 1fr auto;
-  align-items: center;
-  gap: 10px;
-  padding: 10px 14px;
-}
-.rr-os-only__conns { display: flex; }
-.rr-os-only__row { padding-left: 50px; }
 .rr-csub__dest { min-width: 0; display: flex; flex-direction: column; gap: 1px; }
 .rr-csub__host {
   font-family: var(--font-mono);


### PR DESCRIPTION
## Что сделано

- `src/lib/routing-view.js` полностью возвращён к состоянию `v0.2.40`.
- `src/styles/routing.css` полностью возвращён к состоянию `v0.2.40`.
- Удалена OS-only секция «Обходит Ninety» и эвристическое сопоставление Windows TCP snapshot с Clash `/connections`.
- Монитор снова показывает только реальные соединения, которые видит sing-box/Clash API, как в `v0.2.40`.

## Почему

В System Proxy Windows видит сокет приложения как `приложение → 127.0.0.1:<mixed-port>`, а Clash показывает логическое назначение `приложение → удалённый host`. Сопоставление по remote endpoint неизбежно помечало нормальные проксированные соединения как «Обходит Ninety». Это давало ложную диагностику и путало проверку пользовательских правил.

## Важно

`customRulesToSingbox()` и порядок пользовательских route rules в `buildRoute()` уже совпадают с `v0.2.40`, поэтому их не откатывал: замена всего `singbox.js`/`options.js` сломала бы более новые runtime, WARP и lifecycle-изменения без изменения логики правил.

Релиз, тег и workflow dispatch не выполнялись.