### PR TITLE
fix: stabilize active source switching

### DIFF
--- a/.source-switch-reliability-trigger
+++ b/.source-switch-reliability-trigger
@@ -1,1 +1,1 @@
-2026-08-03T09:00:00+03:00
+validate-source-switch-reliability


### PR DESCRIPTION
Applies and validates a focused source-switch reliability patch on Windows. The one-shot workflow will add bounded Clash topology readiness, migrate legacy selector sentinels, bind SourceSwitch to the native runtime generation, persist safe lifecycle diagnostics, converge the initial URLTest group before dataplane verification, and add regression coverage. Release and tags are intentionally out of scope.