### PR TITLE
fix: stabilize active source switching

### DIFF
--- a/.source-switch-reliability-trigger
+++ b/.source-switch-reliability-trigger
@@ -1,1 +1,1 @@
-2026-08-03T09:00:00+03:00
+validate-source-switch-reliability-v2


### PR DESCRIPTION
Second validation attempt after removing a superseded frontend helper caught by zero-warning lint. The Windows workflow applies the same reviewed reliability patch, runs frontend and Rust checks/tests, removes all one-shot patch infrastructure, and commits only the tested product changes. No release or tag is created.