### PR TITLE
fix: stabilize active source switching

### DIFF
--- a/.source-switch-reliability-trigger
+++ b/.source-switch-reliability-trigger
@@ -1,1 +1,1 @@
-2026-08-03T09:00:00+03:00
+validate-source-switch-reliability-v3


### PR DESCRIPTION
Third validation attempt. The previous run correctly stopped at zero-warning lint, then the cleanup step itself exposed a CRLF/LF mismatch. This run uses newline-independent removal, applies the reviewed source-switch patch on Windows, runs the full frontend and Rust validation set, removes all one-shot infrastructure, and commits only tested product changes. No release or tag is created.