### PR TITLE
fix: read the fallback engine version from winws.exe

### DIFF
--- a/.github/workflows/engine-watch.yml
+++ b/.github/workflows/engine-watch.yml
@@ -52,7 +52,14 @@ jobs:
             cp "new/$f" "src-tauri/dpi/bin/$f"
           done
           # engine-version.txt is only a fallback (runtime reads `winws --version`).
-          date -u +'zapret engine %Y-%m-%d (bol-van)' > src-tauri/dpi/engine-version.txt
+          # The version is embedded in winws.exe — the banner is "github version %s"
+          # and the token is e.g. v72.12. Take it from the binary so the fallback
+          # matches what the runtime prints; a build date is not a version. If the
+          # token cannot be read, keep the previous value instead of overwriting it.
+          ver=$(strings -a new/winws.exe | grep -oxE 'v[0-9]+(\.[0-9]+)+' | head -1 || true)
+          if [ -n "$ver" ]; then
+            printf 'zapret %s\n' "$ver" > src-tauri/dpi/engine-version.txt
+          fi
           branch="engine-bump-$(date -u +%Y%m%d-%H%M)"
           git config user.name "ninety-bot"
           git config user.email "noreply@190x4.pw"

--- a/src-tauri/dpi/engine-version.txt
+++ b/src-tauri/dpi/engine-version.txt
@@ -1,1 +1,1 @@
-zapret engine 2026-08-03 (bol-van)
+zapret v72.12


### PR DESCRIPTION
engine-watch писал в `engine-version.txt` дату прогона, поэтому бамп, затронувший только `WinDivert.dll`, заявлял новую версию движка.

Версия зашита в самом `winws.exe` (баннер `github version %s`, токен `v72.12`) — теперь берётся оттуда, формат совпадает с тем, что печатает рантайм и что парсит `parse_engine_version()` в `src-tauri/src/dpi.rs`. Если токен не извлёкся, прежнее значение не перезаписывается.

Заодно возвращает `zapret v72.12`: прогон 2026-08-03 `winws.exe` не менял.